### PR TITLE
fix(设备消息): 解决属性格式化精度不正确的问题

### DIFF
--- a/src/main/java/org/jetlinks/core/metadata/types/NumberType.java
+++ b/src/main/java/org/jetlinks/core/metadata/types/NumberType.java
@@ -68,7 +68,7 @@ public abstract class NumberType<N extends Number> extends AbstractType<NumberTy
             return null;
         }
         Number val = convertScaleNumber(value,
-                                        this.getScale(),
+                                        this.getScale(defaultScale()),
                                         getRound(),
                                         Function.identity());
         if (val == null) {


### PR DESCRIPTION
现象：物模型定义为整型。上报小数值时，格式化结果却为小数。应该为整数