### PR TITLE
fix(核心模块): 修复ArrayType类型中的转换方法的传参实际类型可能为数组而非集合，导致的数据格式转换错误问题

### DIFF
--- a/src/main/java/org/jetlinks/core/metadata/types/ArrayType.java
+++ b/src/main/java/org/jetlinks/core/metadata/types/ArrayType.java
@@ -8,8 +8,8 @@ import org.hswebframework.web.i18n.LocaleUtils;
 import org.jetlinks.core.metadata.Converter;
 import org.jetlinks.core.metadata.DataType;
 import org.jetlinks.core.metadata.ValidateResult;
+import org.springframework.util.CollectionUtils;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -71,8 +71,9 @@ public class ArrayType extends AbstractType<ArrayType> implements DataType, Conv
         // 判断是否为数组
         if (value.getClass().isArray()) {
             // 将数组转换为 List
-            return Arrays
-                .stream((Object[]) value)
+            return CollectionUtils
+                .arrayToList(value)
+                .stream()
                 .map(val -> {
                     if (elementType instanceof Converter) {
                         return ((Converter<?>) elementType).convert(val);

--- a/src/main/java/org/jetlinks/core/metadata/types/ArrayType.java
+++ b/src/main/java/org/jetlinks/core/metadata/types/ArrayType.java
@@ -9,6 +9,7 @@ import org.jetlinks.core.metadata.Converter;
 import org.jetlinks.core.metadata.DataType;
 import org.jetlinks.core.metadata.ValidateResult;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -67,6 +68,19 @@ public class ArrayType extends AbstractType<ArrayType> implements DataType, Conv
 
     @Override
     public List<Object> convert(Object value) {
+        // 判断是否为数组
+        if (value.getClass().isArray()) {
+            // 将数组转换为 List
+            return Arrays
+                .stream((Object[]) value)
+                .map(val -> {
+                    if (elementType instanceof Converter) {
+                        return ((Converter<?>) elementType).convert(val);
+                    }
+                    return val;
+                }).collect(Collectors.toList());
+        }
+        
         if (value instanceof Collection) {
             return ((Collection<?>) value).stream()
                     .map(val -> {
@@ -76,6 +90,7 @@ public class ArrayType extends AbstractType<ArrayType> implements DataType, Conv
                         return val;
                     }).collect(Collectors.toList());
         }
+        
         if(value instanceof String){
             return JSON.parseArray(String.valueOf(value));
         }

--- a/src/test/java/org/jetlinks/core/metadata/types/ArrayTypeTest.java
+++ b/src/test/java/org/jetlinks/core/metadata/types/ArrayTypeTest.java
@@ -39,5 +39,18 @@ public class ArrayTypeTest {
                                                                  "    }\n" +
                                                                  "  }]"));
         assertEquals(data.get(0), data.get(0));
+        
+        Integer[] intArr = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+        String[] strArr = {"字符串1", "字符串2", "字符串3", "字符串4"};
+        ArrayType type1 = new ArrayType();
+        type1.elementType(new IntType());
+        List<Object> intConvert = type1.convert(intArr);
+        
+        ArrayType type2 = new ArrayType();
+        type2.elementType(new StringType());
+        List<Object> strConvert = type2.convert(strArr);
+        
+        assertEquals(intArr[0], intConvert.get(0));
+        assertEquals(strArr[0], strConvert.get(0));
     }
 }

--- a/src/test/java/org/jetlinks/core/metadata/types/ArrayTypeTest.java
+++ b/src/test/java/org/jetlinks/core/metadata/types/ArrayTypeTest.java
@@ -42,6 +42,8 @@ public class ArrayTypeTest {
         
         Integer[] intArr = {1, 2, 3, 4, 5, 6, 7, 8, 9};
         String[] strArr = {"字符串1", "字符串2", "字符串3", "字符串4"};
+        double[] doubleArr = {1.2, 1.2, 3.3, 34.2, 323.1, 434.4};
+        
         ArrayType type1 = new ArrayType();
         type1.elementType(new IntType());
         List<Object> intConvert = type1.convert(intArr);
@@ -50,7 +52,12 @@ public class ArrayTypeTest {
         type2.elementType(new StringType());
         List<Object> strConvert = type2.convert(strArr);
         
+        ArrayType type3 = new ArrayType();
+        type3.elementType(new DoubleType());
+        List<Object> doubleConvert = type3.convert(doubleArr);
+        
         assertEquals(intArr[0], intConvert.get(0));
         assertEquals(strArr[0], strConvert.get(0));
+        assertEquals(doubleArr[0], doubleConvert.get(0));
     }
 }


### PR DESCRIPTION
@zhou-hao 