### PR TITLE
refactor: 添加命令inputs隐藏逻辑；

### DIFF
--- a/src/main/java/org/jetlinks/core/command/CommandMetadataResolver.java
+++ b/src/main/java/org/jetlinks/core/command/CommandMetadataResolver.java
@@ -1,5 +1,6 @@
 package org.jetlinks.core.command;
 
+import com.google.common.collect.Lists;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import org.jetlinks.core.metadata.*;
@@ -13,7 +14,6 @@ import org.springframework.util.StringUtils;
 
 import java.lang.reflect.Method;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * 基于注解{@link Schema}的命令元数据解析器.
@@ -91,12 +91,9 @@ public class CommandMetadataResolver {
                         inputsMap.putIfAbsent(method.getName(), prop);
                     }
                 });
-                return inputsMap
-                    .values()
-                    .stream()
-                    .filter(metadata -> StringUtils.hasText(metadata.getId()))
-                    .sorted(Comparator.comparingLong(m -> indexMap.getOrDefault(m.getId(), Integer.MAX_VALUE)))
-                    .collect(Collectors.toList());
+                List<PropertyMetadata> list = Lists.newArrayList(inputsMap.values());
+                list.sort(Comparator.comparingLong(m -> indexMap.getOrDefault(m.getId(), Integer.MAX_VALUE)));
+                return list;
             }
         }
         DataType objectType = MetadataUtils.parseType(type);
@@ -170,9 +167,6 @@ public class CommandMetadataResolver {
         if (method.getReturnType() == Void.class || method.getParameterCount() != 0) {
             return null;
         }
-        if (schema.hidden()) {
-            return new SimplePropertyMetadata();
-        }
         String name;
         if (StringUtils.hasText(schema.name())) {
             name = schema.name();
@@ -193,6 +187,7 @@ public class CommandMetadataResolver {
         prop.setName(StringUtils.hasText(schema.title()) ? schema.title() : prop.getDescription());
         prop.setValueType(MetadataUtils.parseType(ResolvableType.forMethodReturnType(method, clazz)));
         prop.setExpands(MetadataUtils.parseExpands(method));
+        prop.expand("hidden", schema.hidden());
         return prop;
     }
 

--- a/src/test/java/org/jetlinks/core/command/CommandMetadataResolverTest.java
+++ b/src/test/java/org/jetlinks/core/command/CommandMetadataResolverTest.java
@@ -223,4 +223,27 @@ public class CommandMetadataResolverTest {
 
     }
 
+    public static class Test3Command extends Test1Command {
+
+        @Schema(description = "Str")
+        @Selector(type = "device")
+        public String getStr() {
+            return super.getStr();
+        }
+
+        @Schema(description = "Index")
+        public Integer getIndex() {
+            return super.getIndex();
+        }
+
+    }
+
+    @Test
+    public void testHiddenParentMethod() {
+        FunctionMetadata resolve = CommandMetadataResolver.resolve(Test3Command.class);
+        assertEquals(1, resolve.getInputs().size());
+        assertEquals("index", resolve.getInputs().get(0).getId());
+    }
+
+
 }

--- a/src/test/java/org/jetlinks/core/command/CommandMetadataResolverTest.java
+++ b/src/test/java/org/jetlinks/core/command/CommandMetadataResolverTest.java
@@ -225,7 +225,7 @@ public class CommandMetadataResolverTest {
 
     public static class Test3Command extends Test1Command {
 
-        @Schema(description = "Str")
+        @Schema(description = "Str", hidden = true)
         @Selector(type = "device")
         public String getStr() {
             return super.getStr();

--- a/src/test/java/org/jetlinks/core/command/CommandMetadataResolverTest.java
+++ b/src/test/java/org/jetlinks/core/command/CommandMetadataResolverTest.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 
@@ -241,8 +242,14 @@ public class CommandMetadataResolverTest {
     @Test
     public void testHiddenParentMethod() {
         FunctionMetadata resolve = CommandMetadataResolver.resolve(Test3Command.class);
-        assertEquals(1, resolve.getInputs().size());
-        assertEquals("index", resolve.getInputs().get(0).getId());
+        assertNotNull(resolve.getInputs());
+        assertEquals(2, resolve.getInputs().size());
+        Optional<Object> hidden = resolve
+            .getInputs()
+            .get(0)
+            .getExpand("hidden");
+        assertTrue(hidden.isPresent());
+        assertTrue(((boolean) hidden.get()));
     }
 
 


### PR DESCRIPTION
大佬，有一些命令的inputs会返回两个id的metadata，例如`QueryPropertyLatest`，会返回两个id，但是实际这个命令的id应该只是一个字符串，而不是数组，这样在可视化这边调用的时候，前端显示会有问题。

![image](https://github.com/user-attachments/assets/4dfbe169-d44b-472d-a543-388d9eac1914)
出现这个是因为他的父类`OperationByIdCommand`这个命令中，有一个被schema标注的方法。
![image](https://github.com/user-attachments/assets/53ad5a2e-ffc6-423c-b91d-851034cdf917)
所以我想着子类重写不需要的方法，并标注上schema的属性为hidden，去过滤inputs。
