### PR TITLE
fix: change transport ID removal to use uppercase

### DIFF
--- a/src/main/java/org/jetlinks/core/message/codec/Transports.java
+++ b/src/main/java/org/jetlinks/core/message/codec/Transports.java
@@ -13,7 +13,7 @@ public class Transports {
         transport.forEach(Transports::register);
         return () -> {
             for (Transport t : transport) {
-                all.remove(t.getId().toLowerCase(Locale.ROOT));
+                all.remove(t.getId().toUpperCase());
             }
         };
     }


### PR DESCRIPTION
register(Collection<Transport>)方法返回的Disposable中使用了toLowerCase()而不是toUpperCase()进行移除操作，可能导致无法正确注销协议