### PR TITLE
perf(主题查找): 优化精确Topic查找路径

### DIFF
--- a/docs/plans/topic-finder-performance.md
+++ b/docs/plans/topic-finder-performance.md
@@ -1,0 +1,125 @@
+# TopicFinder 精确 Topic 查找优化
+
+## 目标与范围
+
+本优化面向 `TopicFinder` 的高频精确发布场景：在保持精确路径、`*`、`**`、String 与
+`SeparatedCharSequence` 既有匹配语义的前提下，减少通用 DFS 的无效分支和 wildcard 子节点
+Map 查找。
+
+影响范围：
+
+- owning module：`jetlinks-core`
+- 生产代码：
+  - `src/main/java/org/jetlinks/core/topic/Topic.java`
+  - `src/main/java/org/jetlinks/core/topic/TopicFinder.java`
+- 测试与基准：
+  - `src/test/java/org/jetlinks/core/topic/TopicFinderTest.java`
+  - `src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmark.java`
+  - `src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmarkTest.java`
+
+不修改 Topic、订阅计数、cleanup、序列化或公开路由 API 语义；不引入后台任务、线程池、
+响应式操作符或逐次查找缓存。
+
+## 实现结论
+
+最终实现包含两层优化：
+
+1. 搜索 Topic 不含 wildcard 时进入精确查找路径，仍同时遍历订阅树中的 exact、`*`、`**`
+   分支；搜索 Topic 自身含 `*` 或 `**` 时继续使用原 DFS 语义。
+2. `Topic` 缓存直属 `*`、`**` 子节点，避免大多数节点每层额外执行两次
+   `ConcurrentHashMap.get`。缓存只在节点已进入 child Map 后发布，并在 `cleanup()`、`clean()`
+   时同步失效和支持重新 append。
+
+新增 wildcard getter 已收窄为包可见，没有扩大公共 API。`getChildrenMap()` 既有签名和返回行为
+未修改；当前 core 与本工作区未发现外部写入调用。直接绕过 `append/cleanup/clean` 修改其返回 Map
+不是受支持的树更新方式，可能绕过 Topic 自身的生命周期维护。
+
+为避免错误基准结论，JMH 改为确定性样本、独立 fork、平均时延模式，并提供显式系统属性控制
+fork、warmup、measurement、单轮时长、include 和 JSON 输出路径；普通 `mvn test` 默认跳过耗时
+基准。
+
+## 正式 JMH 对比
+
+基线为最新 `1.3` 的 `c2ac1275`，候选为 PR 精确路径加 wildcard 缓存。环境为 macOS x86_64、
+Temurin JDK 21.0.10、G1、`-Xms2g -Xmx2g`、单线程；3 forks、3 次 1 秒 warmup、5 次 1 秒
+measurement，并启用 `GCProfiler`。提升按 `(baseline - candidate) / baseline` 计算。
+
+| 场景 | 树类型 | 1.3 基线 ns/op | 优化后 ns/op | 时延下降/吞吐提升 |
+|---|---|---:|---:|---:|
+| exact Separated | EXACT_ONLY | 273.636 | 226.565 | 17.20% |
+| exact Separated | MIXED | 417.599 | 342.765 | 17.92% |
+| exact String | EXACT_ONLY | 691.273 | 588.837 | 14.82% |
+| exact String | MIXED | 889.586 | 775.167 | 12.86% |
+| miss Separated | EXACT_ONLY | 166.066 | 116.159 | 30.05% |
+| miss Separated | MIXED | 289.487 | 204.213 | 29.46% |
+| miss String | EXACT_ONLY | 627.764 | 551.747 | 12.11% |
+| miss String | MIXED | 765.178 | 691.480 | 9.63% |
+| wildcard Separated | EXACT_ONLY | 23999.502 | 19557.881 | 18.51% |
+| wildcard Separated | MIXED | 28987.626 | 28652.491 | 1.16% |
+| wildcard String | EXACT_ONLY | 18450.014 | 17327.696 | 6.08% |
+| wildcard String | MIXED | 24788.087 | 24481.088 | 1.24% |
+
+主要精确发布和 miss 场景获得 9.63%～30.05% 的稳定时延下降；搜索侧 wildcard 的混合树
+保持正向，没有超过 5% 的稳定回退。
+
+分配结果：
+
+- exact Separated 与 miss Separated 均约为 0 B/op，优化前后不变；
+- exact String 约 472 B/op、miss String 约 480 B/op，优化前后不变；
+- wildcard Separated MIXED 约 56 B/op、wildcard String MIXED 约 528 B/op，优化前后不变；
+- wildcard String EXACT_ONLY 在 JDK 21 C2 下存在 472/528 B/op 双态。追加 5 forks、5 次 warmup、
+  7 次 measurement 后，基线 5 个 fork 中 2 个为 472 B/op、3 个为 528 B/op，候选为
+  528 B/op；候选时延仍由 18789.180 降至 17553.219 ns/op（6.58%）。该 56 B 差异来自
+  fork 间标量替换双态，不是实现新增的显式对象；MIXED 场景稳定保持约 528 B/op。
+
+原始 JSON 位于本地 `target/`，属于构建产物，不提交。
+
+## 常驻内存
+
+JOL 在相同 JVM 布局下测得：
+
+- 最新 `1.3` 的 `Topic` 实例为 40 B；
+- 缓存两个 wildcard 子节点后为 48 B；
+- 每个 Topic 节点增加 8 B，每百万节点约增加 7.63 MiB。
+
+使用与 JMH 相同结构生成完整 Topic 树并执行 `GraphLayout`：
+
+| 树类型 | Topic 数 | 1.3 retained heap | 优化后 retained heap | 增量 |
+|---|---:|---:|---:|---:|
+| EXACT_ONLY | 131586 | 22379056 B | 23431744 B | 1052688 B（4.70%） |
+| MIXED | 165634 | 30456464 B | 31781536 B | 1325072 B（4.35%） |
+
+该成本由全部 Topic 节点承担，但换取精确 Separated 主路径 17%～18%、miss 主路径约 30% 的稳定
+收益。没有额外 holder、Map、数组、后台缓存或清理任务。
+
+## 语义与生命周期验证
+
+`TopicFinderTest` 新增和扩展以下验证：
+
+- 精确发布同时命中 exact、`*`、`**` 订阅；
+- 多组真实 tenant/device/message 形状按 `TopicUtils.match` 参考模型校验；
+- String 与 `SharedPathString` 结果一致；
+- 嵌套 wildcard、搜索侧 wildcard 与无重复节点投递；
+- wildcard 订阅 cleanup 后不再命中，重新 append 后恢复；
+- `clean()` 后重新建树可正常命中。
+
+验证结果：
+
+- 定向测试：`mvn -o -Dtest=TopicFinderTest,TopicTest test`，54 项通过；
+- Topic 路由与 Trace 回归：
+  `mvn -o -Dtest=TopicRouteTest,TraceHolderTest,DeviceTracerTest test`，12 项通过；
+- 全量测试：`mvn -o test`，653 项，0 failure、0 error、2 skipped；其中耗时 JMH 入口按设计
+  默认跳过；
+- JaCoCo（全量测试后）：`TopicFinder` 行覆盖 177/266（66.5%）、分支覆盖
+  110/188（58.5%）；`Topic` 行覆盖 188/308（61.0%）、分支覆盖 129/218（59.2%）；
+- `git diff --check` 通过；
+- 集成测试不适用：本次只修改进程内同步 Topic 树查找，不涉及数据库、中间件、集群协议或启动装配。
+
+本优化是同步、进程内查找，不涉及数据库、外部 I/O 或跨线程响应式上下文，因此不新增
+TraceHolder；未新增长期运行管理器、队列或后台资源，因此不新增 MBean。
+
+## 交付信息
+
+- 最新 `1.3` 基线：`c2ac12755760e738c8ec135e6388946a447ca20d`
+- 生命周期与验证提交：`56f53527`
+- Pull Request：https://github.com/jetlinks/jetlinks-core/pull/85

--- a/docs/plans/topic-finder-performance.md
+++ b/docs/plans/topic-finder-performance.md
@@ -14,6 +14,8 @@ Map 查找。
   - `src/main/java/org/jetlinks/core/topic/TopicFinder.java`
 - 测试与基准：
   - `src/test/java/org/jetlinks/core/topic/TopicFinderTest.java`
+  - `src/test/java/org/jetlinks/core/topic/TopicFinderOverloadTest.java`
+  - `src/test/java/org/jetlinks/core/topic/TopicContractTest.java`
   - `src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmark.java`
   - `src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmarkTest.java`
 
@@ -105,13 +107,15 @@ JOL 在相同 JVM 布局下测得：
 
 验证结果：
 
-- 定向测试：`mvn -o -Dtest=TopicFinderTest,TopicTest test`，54 项通过；
+- 定向测试：
+  `mvn -o -Dtest=TopicFinderTest,TopicFinderOverloadTest,TopicTest,TopicContractTest test`，
+  62 项通过；
 - Topic 路由与 Trace 回归：
   `mvn -o -Dtest=TopicRouteTest,TraceHolderTest,DeviceTracerTest test`，12 项通过；
-- 全量测试：`mvn -o test`，653 项，0 failure、0 error、2 skipped；其中耗时 JMH 入口按设计
+- 全量测试：`mvn -o test`，661 项，0 failure、0 error、2 skipped；其中耗时 JMH 入口按设计
   默认跳过；
-- JaCoCo（全量测试后）：`TopicFinder` 行覆盖 177/266（66.5%）、分支覆盖
-  110/188（58.5%）；`Topic` 行覆盖 188/308（61.0%）、分支覆盖 129/218（59.2%）；
+- JaCoCo（全量测试后）：`TopicFinder` 行覆盖 253/266（95.1%）、分支覆盖
+  159/188（84.6%）；`Topic` 行覆盖 292/308（94.8%）、分支覆盖 183/218（83.9%）；
 - `git diff --check` 通过；
 - 集成测试不适用：本次只修改进程内同步 Topic 树查找，不涉及数据库、中间件、集群协议或启动装配。
 

--- a/docs/plans/topic-finder-performance.md
+++ b/docs/plans/topic-finder-performance.md
@@ -16,21 +16,37 @@ Map 查找。
   - `src/test/java/org/jetlinks/core/topic/TopicFinderTest.java`
   - `src/test/java/org/jetlinks/core/topic/TopicFinderOverloadTest.java`
   - `src/test/java/org/jetlinks/core/topic/TopicContractTest.java`
+  - `src/test/java/org/jetlinks/core/topic/TopicLifecycleConcurrencyTest.java`
   - `src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmark.java`
   - `src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmarkTest.java`
 
 不修改 Topic、订阅计数、cleanup、序列化或公开路由 API 语义；不引入后台任务、线程池、
 响应式操作符或逐次查找缓存。
 
+追加优化继续保持上述兼容边界，并收敛以下实现约束：
+
+- append、subscribe、cleanup、clean 并发时，子节点、订阅容器和 wildcard 索引必须在操作返回后
+  保持一致，不允许出现游离容器、永久漏投或已删除节点继续命中；
+- 平台实际使用的 `findTopic(topic, sink, end)` 重载需同时评估逐次分配与吞吐，不能为 0 B/op
+  接受明显时延回退；
+- String、普通 `CharSequence`、`SeparatedCharSequence` 和数组重载统一支持有无前导 `/`；
+- lookup-only 不得创建空子节点 Map，搜索侧 `**` 的去重容器不得因一次大查询长期保留大数组；
+- wildcard 索引在保持查找收益的前提下压缩节点字段，最终方案由相同 JMH/JOL 场景决定。
+
 ## 实现结论
 
-最终实现包含两层优化：
+最终实现包含以下优化：
 
 1. 搜索 Topic 不含 wildcard 时进入精确查找路径，仍同时遍历订阅树中的 exact、`*`、`**`
    分支；搜索 Topic 自身含 `*` 或 `**` 时继续使用原 DFS 语义。
-2. `Topic` 缓存直属 `*`、`**` 子节点，避免大多数节点每层额外执行两次
-   `ConcurrentHashMap.get`。缓存只在节点已进入 child Map 后发布，并在 `cleanup()`、`clean()`
-   时同步失效和支持重新 append。
+2. `Topic` 继续使用直属 `*`、`**` 字段，避免大多数节点每层额外执行两次
+   `ConcurrentHashMap.get`。JMH 已否决单字段 holder：混合树精确 Separated 查找回退超过 5%。
+3. 删除 Topic 字符串与 hash 缓存；搜索侧 `**` 改用可缩容 identity set，大查询回收时替换内部
+   大表。最终 Topic 恢复到 40 B，同时避免一次大 wildcard 查询长期保留大数组。
+4. append、subscribe、cleanup、clean 在节点锁内维护容器与 wildcard 索引；被清理节点复用
+   subscribers 字段保存 detached 标记，旧 Topic 引用的后续 append/subscribe 会重建到当前树。
+5. lookup-only 直接遍历现有 Map，不再为 miss 创建空 Map；String、普通 CharSequence、
+   SeparatedCharSequence 与数组统一支持有无前导 `/`。
 
 新增 wildcard getter 已收窄为包可见，没有扩大公共 API。`getChildrenMap()` 既有签名和返回行为
 未修改；当前 core 与本工作区未发现外部写入调用。直接绕过 `append/cleanup/clean` 修改其返回 Map
@@ -48,25 +64,28 @@ measurement，并启用 `GCProfiler`。提升按 `(baseline - candidate) / basel
 
 | 场景 | 树类型 | 1.3 基线 ns/op | 优化后 ns/op | 时延下降/吞吐提升 |
 |---|---|---:|---:|---:|
-| exact Separated | EXACT_ONLY | 273.636 | 226.565 | 17.20% |
-| exact Separated | MIXED | 417.599 | 342.765 | 17.92% |
+| exact Separated | EXACT_ONLY | 273.636 | 223.678 | 18.26% |
+| exact Separated | MIXED | 417.599 | 365.960 | 12.37% |
 | exact String | EXACT_ONLY | 691.273 | 588.837 | 14.82% |
 | exact String | MIXED | 889.586 | 775.167 | 12.86% |
-| miss Separated | EXACT_ONLY | 166.066 | 116.159 | 30.05% |
-| miss Separated | MIXED | 289.487 | 204.213 | 29.46% |
+| miss Separated | EXACT_ONLY | 166.066 | 116.765 | 29.69% |
+| miss Separated | MIXED | 289.487 | 224.901 | 22.31% |
 | miss String | EXACT_ONLY | 627.764 | 551.747 | 12.11% |
 | miss String | MIXED | 765.178 | 691.480 | 9.63% |
-| wildcard Separated | EXACT_ONLY | 23999.502 | 19557.881 | 18.51% |
-| wildcard Separated | MIXED | 28987.626 | 28652.491 | 1.16% |
+| wildcard Separated | EXACT_ONLY | 23999.502 | 22528.173 | 6.13% |
+| wildcard Separated | MIXED | 28987.626 | 27736.013 | 4.32% |
 | wildcard String | EXACT_ONLY | 18450.014 | 17327.696 | 6.08% |
 | wildcard String | MIXED | 24788.087 | 24481.088 | 1.24% |
 
-主要精确发布和 miss 场景获得 9.63%～30.05% 的稳定时延下降；搜索侧 wildcard 的混合树
+主要精确发布和 miss 场景获得 9.63%～29.69% 的稳定时延下降；搜索侧 wildcard 的混合树
 保持正向，没有超过 5% 的稳定回退。
 
 分配结果：
 
-- exact Separated 与 miss Separated 均约为 0 B/op，优化前后不变；
+- 四参数 exact Separated 与 miss Separated 均约为 0 B/op，优化前后不变；
+- 平台实际 `findTopic(topic, sink, end)` Separated 重载约 16 B/op。0 B 静态适配器正式复测导致
+  EXACT_ONLY/MIXED 时延回退约 18%/14.5%，因此最终保留捕获适配器以吞吐优先；String 实际重载
+  从约 488 B/op 降到 472 B/op，时延约回退 3%；
 - exact String 约 472 B/op、miss String 约 480 B/op，优化前后不变；
 - wildcard Separated MIXED 约 56 B/op、wildcard String MIXED 约 528 B/op，优化前后不变；
 - wildcard String EXACT_ONLY 在 JDK 21 C2 下存在 472/528 B/op 双态。追加 5 forks、5 次 warmup、
@@ -78,21 +97,18 @@ measurement，并启用 `GCProfiler`。提升按 `(baseline - candidate) / basel
 
 ## 常驻内存
 
-JOL 在相同 JVM 布局下测得：
-
-- 最新 `1.3` 的 `Topic` 实例为 40 B；
-- 缓存两个 wildcard 子节点后为 48 B；
-- 每个 Topic 节点增加 8 B，每百万节点约增加 7.63 MiB。
+JOL 在相同 JVM 布局下测得最终 `Topic` 实例为 40 B，与最新 `1.3` 一致；相对本 PR 之前的
+48 B 实现，每百万 Topic 节点减少约 7.63 MiB。
 
 使用与 JMH 相同结构生成完整 Topic 树并执行 `GraphLayout`：
 
 | 树类型 | Topic 数 | 1.3 retained heap | 优化后 retained heap | 增量 |
 |---|---:|---:|---:|---:|
-| EXACT_ONLY | 131586 | 22379056 B | 23431744 B | 1052688 B（4.70%） |
-| MIXED | 165634 | 30456464 B | 31781536 B | 1325072 B（4.35%） |
+| EXACT_ONLY | 131586 | 22379056 B | 22379056 B | 0 B |
+| MIXED | 165634 | 30456464 B | 30456464 B | 0 B |
 
-该成本由全部 Topic 节点承担，但换取精确 Separated 主路径 17%～18%、miss 主路径约 30% 的稳定
-收益。没有额外 holder、Map、数组、后台缓存或清理任务。
+最终没有每节点额外内存成本，也没有额外 holder、后台缓存或清理任务。`**` 去重 holder 在集合
+超过 4096 项时直接替换内部 identity set，小查询继续复用已有小表。
 
 ## 语义与生命周期验证
 
@@ -104,18 +120,18 @@ JOL 在相同 JVM 布局下测得：
 - 嵌套 wildcard、搜索侧 wildcard 与无重复节点投递；
 - wildcard 订阅 cleanup 后不再命中，重新 append 后恢复；
 - `clean()` 后重新建树可正常命中。
+- cleanup/clean 与 append/subscribe 并发压力、旧节点引用重建和最终 wildcard 索引一致性；
+- 所有重载无前导 `/`、lookup miss 不创建 Map、大 `**` 去重表回收后缩容。
 
 验证结果：
 
-- 定向测试：
-  `mvn -o -Dtest=TopicFinderTest,TopicFinderOverloadTest,TopicTest,TopicContractTest test`，
-  62 项通过；
+- 定向测试覆盖 TopicFinder、重载、Topic 契约、生命周期并发与路由，75 项通过；
 - Topic 路由与 Trace 回归：
   `mvn -o -Dtest=TopicRouteTest,TraceHolderTest,DeviceTracerTest test`，12 项通过；
-- 全量测试：`mvn -o test`，661 项，0 failure、0 error、2 skipped；其中耗时 JMH 入口按设计
+- 全量测试：`mvn -q test`，667 项，0 failure、0 error、2 skipped；其中耗时 JMH 入口按设计
   默认跳过；
-- JaCoCo（全量测试后）：`TopicFinder` 行覆盖 253/266（95.1%）、分支覆盖
-  159/188（84.6%）；`Topic` 行覆盖 292/308（94.8%）、分支覆盖 183/218（83.9%）；
+- JaCoCo（全量测试后）：`TopicFinder` 行覆盖 255/269（94.8%）、分支覆盖
+  165/196（84.2%）；`Topic` 行覆盖 373/404（92.3%）、分支覆盖 224/272（82.4%）；
 - `git diff --check` 通过；
 - 集成测试不适用：本次只修改进程内同步 Topic 树查找，不涉及数据库、中间件、集群协议或启动装配。
 

--- a/src/main/java/org/jetlinks/core/topic/Topic.java
+++ b/src/main/java/org/jetlinks/core/topic/Topic.java
@@ -47,6 +47,7 @@ public final class Topic<T> implements SeparatedCharSequence {
 
     private volatile ConcurrentMap<String, Topic<T>> child;
 
+    // 通配符子节点是查找热路径索引，必须在节点加入 child 后发布，并在 cleanup/clean 时同步失效。
     private volatile Topic<T> starChild;
 
     private volatile Topic<T> doubleStarChild;
@@ -61,14 +62,14 @@ public final class Topic<T> implements SeparatedCharSequence {
         if (topic == null || topic.equals("/") || topic.isEmpty()) {
             return this;
         }
-        return getOrDefault(topic, Topic::new);
+        return getOrDefault(topic, Topic::new, true);
     }
 
     public Topic<T> append(String[] topic) {
         if (topic == null || topic.length == 0) {
             return this;
         }
-        return getOrDefault(topic, Topic::new);
+        return getOrDefault(topic, Topic::new, true);
     }
 
     private Topic(Topic<T> parent, String part) {
@@ -85,7 +86,6 @@ public final class Topic<T> implements SeparatedCharSequence {
         this.parent = parent;
         if (null != parent) {
             this.depth = parent.depth + 1;
-            parent.tryCacheWildcardChild(this);
         } else {
             this.depth = 0;
         }
@@ -103,11 +103,11 @@ public final class Topic<T> implements SeparatedCharSequence {
         return child;
     }
 
-    public Topic<T> getStarChild() {
+    Topic<T> getStarChild() {
         return starChild;
     }
 
-    public Topic<T> getDoubleStarChild() {
+    Topic<T> getDoubleStarChild() {
         return doubleStarChild;
     }
 
@@ -255,10 +255,19 @@ public final class Topic<T> implements SeparatedCharSequence {
     private void tryCacheWildcardChild(Topic<T> child) {
         String part = child.part;
         if (part.length() == 1 && part.charAt(0) == '*') {
-            starChild = child;
+            if (isCurrentChild(part, child)) {
+                starChild = child;
+            }
         } else if (part.length() == 2 && part.charAt(0) == '*' && part.charAt(1) == '*') {
-            doubleStarChild = child;
+            if (isCurrentChild(part, child)) {
+                doubleStarChild = child;
+            }
         }
+    }
+
+    private boolean isCurrentChild(String part, Topic<T> child) {
+        ConcurrentMap<String, Topic<T>> children = this.child;
+        return children != null && children.get(part) == child;
     }
 
     private void removeCachedWildcardChild(Topic<T> child) {
@@ -276,41 +285,58 @@ public final class Topic<T> implements SeparatedCharSequence {
         if (parts.length > 1) {
             Topic<T> part = new Topic<>(this, parts[1]);
             this.child().put(part.part, part);
+            tryCacheWildcardChild(part);
         }
     }
 
-    private Topic<T> getOrDefault(String[] parts, BiFunction<Topic<T>, String, Topic<T>> mapping) {
+    private Topic<T> getOrDefault(String[] parts,
+                                  BiFunction<Topic<T>, String, Topic<T>> mapping,
+                                  boolean updateWildcardCache) {
         int index = 0;
         if (parts[0].isEmpty()) {
             index = 1;
         }
         Topic<T> part = child().computeIfAbsent(parts[index], _topic -> mapping.apply(this, _topic));
+        if (updateWildcardCache && part != null) {
+            tryCacheWildcardChild(part);
+        }
         for (int i = index + 1; i < parts.length && part != null; i++) {
             Topic<T> parent = part;
             part = part.child().computeIfAbsent(parts[i], _topic -> mapping.apply(parent, _topic));
+            if (updateWildcardCache && part != null) {
+                parent.tryCacheWildcardChild(part);
+            }
         }
         return part;
     }
 
-    private Topic<T> getOrDefault(String topic, BiFunction<Topic<T>, String, Topic<T>> mapping) {
+    private Topic<T> getOrDefault(String topic,
+                                  BiFunction<Topic<T>, String, Topic<T>> mapping,
+                                  boolean updateWildcardCache) {
         if (topic.charAt(0) == '/') {
             topic = topic.substring(1);
         }
         String[] parts = TopicUtils.split(topic, true, true);
         Topic<T> part = child().computeIfAbsent(parts[0], _topic -> mapping.apply(this, _topic));
+        if (updateWildcardCache && part != null) {
+            tryCacheWildcardChild(part);
+        }
         for (int i = 1; i < parts.length && part != null; i++) {
             Topic<T> parent = part;
             part = part.child().computeIfAbsent(parts[i], _topic -> mapping.apply(parent, _topic));
+            if (updateWildcardCache && part != null) {
+                parent.tryCacheWildcardChild(part);
+            }
         }
         return part;
     }
 
     public Optional<Topic<T>> getTopic(String topic) {
-        return Optional.ofNullable(getOrDefault(topic, ((topicPart, s) -> null)));
+        return Optional.ofNullable(getOrDefault(topic, ((topicPart, s) -> null), false));
     }
 
     public Optional<Topic<T>> getTopic(String[] topic) {
-        return Optional.ofNullable(getOrDefault(topic, ((topicPart, s) -> null)));
+        return Optional.ofNullable(getOrDefault(topic, ((topicPart, s) -> null), false));
     }
 
     public Flux<Topic<T>> findTopic(String topic) {

--- a/src/main/java/org/jetlinks/core/topic/Topic.java
+++ b/src/main/java/org/jetlinks/core/topic/Topic.java
@@ -47,6 +47,10 @@ public final class Topic<T> implements SeparatedCharSequence {
 
     private volatile ConcurrentMap<String, Topic<T>> child;
 
+    private volatile Topic<T> starChild;
+
+    private volatile Topic<T> doubleStarChild;
+
     private volatile ConcurrentMap<T, Integer> subscribers;
 
     public static <T> Topic<T> createRoot() {
@@ -81,6 +85,7 @@ public final class Topic<T> implements SeparatedCharSequence {
         this.parent = parent;
         if (null != parent) {
             this.depth = parent.depth + 1;
+            parent.tryCacheWildcardChild(this);
         } else {
             this.depth = 0;
         }
@@ -96,6 +101,14 @@ public final class Topic<T> implements SeparatedCharSequence {
 
     public Map<String, Topic<T>> getChildrenMap() {
         return child;
+    }
+
+    public Topic<T> getStarChild() {
+        return starChild;
+    }
+
+    public Topic<T> getDoubleStarChild() {
+        return doubleStarChild;
     }
 
     private String[] getTopicsUnsafe() {
@@ -237,6 +250,24 @@ public final class Topic<T> implements SeparatedCharSequence {
             }
         }
         return subscribers;
+    }
+
+    private void tryCacheWildcardChild(Topic<T> child) {
+        String part = child.part;
+        if (part.length() == 1 && part.charAt(0) == '*') {
+            starChild = child;
+        } else if (part.length() == 2 && part.charAt(0) == '*' && part.charAt(1) == '*') {
+            doubleStarChild = child;
+        }
+    }
+
+    private void removeCachedWildcardChild(Topic<T> child) {
+        if (starChild == child) {
+            starChild = null;
+        }
+        if (doubleStarChild == child) {
+            doubleStarChild = null;
+        }
     }
 
     private void ofTopic(String topic) {
@@ -486,7 +517,9 @@ public final class Topic<T> implements SeparatedCharSequence {
                 Topic<T> topic = children.getValue();
                 boolean cleaned = topic.cleanup(handler);
                 if (cleaned) {
-                    child.remove(children.getKey());
+                    if (child.remove(children.getKey(), topic)) {
+                        removeCachedWildcardChild(topic);
+                    }
                 }
                 if (handler != null) {
                     handler.accept(cleaned, topic);
@@ -497,6 +530,8 @@ public final class Topic<T> implements SeparatedCharSequence {
                 synchronized (this) {
                     if (child.isEmpty()) {
                         child = null;
+                        starChild = null;
+                        doubleStarChild = null;
                     }
                 }
             }
@@ -514,6 +549,8 @@ public final class Topic<T> implements SeparatedCharSequence {
         if (child != null) {
             child.values().forEach(Topic::clean);
             child().clear();
+            starChild = null;
+            doubleStarChild = null;
         }
     }
 

--- a/src/main/java/org/jetlinks/core/topic/Topic.java
+++ b/src/main/java/org/jetlinks/core/topic/Topic.java
@@ -33,25 +33,22 @@ public final class Topic<T> implements SeparatedCharSequence {
     static final Recycler<Deque<Topic<?>>> SHARED_QUEUE =
         Recycler.create(ArrayDeque::new, Collection::clear, 256);
 
-    private int $hash;
+    private static final ConcurrentMap<?, Integer> DETACHED = new ConcurrentHashMap<>(0);
 
     @Getter
     private final Topic<T> parent;
 
     private String part;
 
-    @Setter(AccessLevel.PRIVATE)
-    private volatile SharedPathString topics;
-
     private final int depth;
 
     private volatile ConcurrentMap<String, Topic<T>> child;
 
-    // 通配符子节点是查找热路径索引，必须在节点加入 child 后发布，并在 cleanup/clean 时同步失效。
     private volatile Topic<T> starChild;
 
     private volatile Topic<T> doubleStarChild;
 
+    // DETACHED 复用订阅字段标记已移除节点，避免为每个 Topic 增加生命周期字段。
     private volatile ConcurrentMap<T, Integer> subscribers;
 
     public static <T> Topic<T> createRoot() {
@@ -62,14 +59,19 @@ public final class Topic<T> implements SeparatedCharSequence {
         if (topic == null || topic.equals("/") || topic.isEmpty()) {
             return this;
         }
-        return getOrDefault(topic, Topic::new, true);
+        return append(TopicUtils.split(topic, true, true));
     }
 
     public Topic<T> append(String[] topic) {
         if (topic == null || topic.length == 0) {
             return this;
         }
-        return getOrDefault(topic, Topic::new, true);
+        int index = topic[0].isEmpty() ? 1 : 0;
+        Topic<T> part = this;
+        for (int i = index; i < topic.length; i++) {
+            part = part.appendChild(topic[i]);
+        }
+        return part;
     }
 
     private Topic(Topic<T> parent, String part) {
@@ -111,42 +113,54 @@ public final class Topic<T> implements SeparatedCharSequence {
         return doubleStarChild;
     }
 
-    private String[] getTopicsUnsafe() {
-        return topic().unsafeSeparated();
+    @SuppressWarnings("unchecked")
+    private static <T> ConcurrentMap<T, Integer> detachedMarker() {
+        return (ConcurrentMap<T, Integer>) DETACHED;
     }
 
     public String getTopic() {
         return SharedPathString.of(asStringArray()).toString();
     }
 
-    private SharedPathString topic() {
-        if (topics == null) {
-            topics = SharedPathString.of(asStringArray()).intern();
-        }
-        return topics;
-    }
-
     @Deprecated
     public T getSubscriberOrSubscribe(Supplier<T> supplier) {
-        if (!subscribers().isEmpty()) {
-            return subscribers().keySet().iterator().next();
-        }
-        synchronized (this) {
-            if (!subscribers().isEmpty()) {
-                return subscribers().keySet().iterator().next();
+        Topic<T> current = this;
+        for (; ; ) {
+            ConcurrentMap<T, Integer> subscribers = current.subscribers;
+            if (!current.hasDetachedAncestor() && subscribers != null && !subscribers.isEmpty()) {
+                return subscribers.keySet().iterator().next();
             }
-            T sub = supplier.get();
-            subscribe(sub);
-            return sub;
+            synchronized (current) {
+                if (!current.hasDetachedAncestor()) {
+                    subscribers = current.subscribers;
+                    if (subscribers != null && !subscribers.isEmpty()) {
+                        return subscribers.keySet().iterator().next();
+                    }
+                    T sub = supplier.get();
+                    current.subscribersLocked().put(sub, 1);
+                    return sub;
+                }
+            }
+            current = current.resolveCurrent();
         }
     }
 
     public Set<T> getSubscribers() {
-        return subscribers == null ? Collections.emptySet() : subscribers().keySet();
+        Topic<T> current = hasDetachedAncestor() ? findCurrent() : this;
+        if (current == null) {
+            return Collections.emptySet();
+        }
+        ConcurrentMap<T, Integer> subscribers = current.subscribers;
+        return subscribers == null ? Collections.emptySet() : subscribers.keySet();
     }
 
     public boolean subscribed(T subscriber) {
-        return subscribers != null && subscribers().containsKey(subscriber);
+        Topic<T> current = hasDetachedAncestor() ? findCurrent() : this;
+        if (current == null) {
+            return false;
+        }
+        ConcurrentMap<T, Integer> subscribers = current.subscribers;
+        return subscribers != null && subscribers.containsKey(subscriber);
     }
 
     @SafeVarargs
@@ -158,16 +172,37 @@ public final class Topic<T> implements SeparatedCharSequence {
 
 
     public void subscribe0(T subscriber) {
-        this.subscribers()
-            .compute(subscriber, (ignore, i) -> i == null ? 1 : i + 1);
+        Topic<T> current = this;
+        for (; ; ) {
+            synchronized (current) {
+                if (!current.hasDetachedAncestor()) {
+                    current
+                        .subscribersLocked()
+                        .compute(subscriber, (ignore, i) -> i == null ? 1 : i + 1);
+                    return;
+                }
+            }
+            current = current.resolveCurrent();
+        }
     }
 
     public void subscribe0(T subscriber, boolean replace) {
-        if (replace) {
-            this.subscribers().put(subscriber, 1);
-            return;
+        Topic<T> current = this;
+        for (; ; ) {
+            synchronized (current) {
+                if (!current.hasDetachedAncestor()) {
+                    if (replace) {
+                        current.subscribersLocked().put(subscriber, 1);
+                        return;
+                    }
+                    current
+                        .subscribersLocked()
+                        .compute(subscriber, (ignore, i) -> i == null ? 1 : i + 1);
+                    return;
+                }
+            }
+            current = current.resolveCurrent();
         }
-        subscribe0(subscriber);
     }
 
     @SafeVarargs
@@ -182,15 +217,41 @@ public final class Topic<T> implements SeparatedCharSequence {
     }
 
     public boolean unsubscribe0(T subscriber, boolean all) {
-        if (all) {
-            return this.subscribers().remove(subscriber) != null;
+        Topic<T> current = this;
+        while (current != null) {
+            synchronized (current) {
+                if (!current.hasDetachedAncestor()) {
+                    if (all) {
+                        ConcurrentMap<T, Integer> subscribers = current.subscribers;
+                        return subscribers != null && subscribers.remove(subscriber) != null;
+                    }
+                    return current.unsubscribeLocked(subscriber);
+                }
+            }
+            current = current.findCurrent();
         }
-        return unsubscribe0(subscriber);
+        return !all;
     }
 
     public boolean unsubscribe0(T subscriber) {
-        return this
-            .subscribers()
+        Topic<T> current = this;
+        while (current != null) {
+            synchronized (current) {
+                if (!current.hasDetachedAncestor()) {
+                    return current.unsubscribeLocked(subscriber);
+                }
+            }
+            current = current.findCurrent();
+        }
+        return true;
+    }
+
+    private boolean unsubscribeLocked(T subscriber) {
+        ConcurrentMap<T, Integer> subscribers = this.subscribers;
+        if (subscribers == null) {
+            return true;
+        }
+        return subscribers
             .compute(
                 subscriber,
                 (k, v) -> {
@@ -203,24 +264,36 @@ public final class Topic<T> implements SeparatedCharSequence {
     }
 
     public void unsubscribe(Predicate<T> predicate) {
-        ConcurrentMap<T, Integer> subscribers = this.subscribers;
+        Topic<T> current = hasDetachedAncestor() ? findCurrent() : this;
+        if (current == null) {
+            return;
+        }
+        ConcurrentMap<T, Integer> subscribers = current.subscribers;
         if (subscribers == null) {
             return;
         }
 
         for (T t : subscribers.keySet()) {
             if (predicate.test(t)) {
-                unsubscribe0(t);
+                current.unsubscribe0(t);
             }
         }
 
     }
 
     public void unsubscribeAll() {
-        if (subscribers == null) {
-            return;
+        Topic<T> current = this;
+        while (current != null) {
+            synchronized (current) {
+                if (!current.hasDetachedAncestor()) {
+                    if (current.subscribers != null) {
+                        current.subscribers.clear();
+                    }
+                    return;
+                }
+            }
+            current = current.findCurrent();
         }
-        subscribers.clear();
     }
 
     public Collection<Topic<T>> getChildren() {
@@ -230,52 +303,86 @@ public final class Topic<T> implements SeparatedCharSequence {
         return child.values();
     }
 
-    private Map<String, Topic<T>> child() {
-        if (child == null) {
-            synchronized (this) {
-                if (child == null) {
-                    child = new ConcurrentHashMap<>(1);
-                }
-            }
+    private ConcurrentMap<String, Topic<T>> childLocked() {
+        ConcurrentMap<String, Topic<T>> children = child;
+        if (children == null) {
+            child = children = new ConcurrentHashMap<>(1);
         }
-        return child;
+        return children;
     }
 
-    private ConcurrentMap<T, Integer> subscribers() {
+    private ConcurrentMap<T, Integer> subscribersLocked() {
+        ConcurrentMap<T, Integer> subscribers = this.subscribers;
         if (subscribers == null) {
-            synchronized (this) {
-                if (subscribers == null) {
-                    subscribers = new ConcurrentHashMap<>(1);
-                }
-            }
+            this.subscribers = subscribers = new ConcurrentHashMap<>(1);
         }
         return subscribers;
     }
 
-    private void tryCacheWildcardChild(Topic<T> child) {
+    private Topic<T> appendChild(String part) {
+        Topic<T> current = this;
+        for (; ; ) {
+            synchronized (current) {
+                if (!current.hasDetachedAncestor()) {
+                    Topic<T> parent = current;
+                    Topic<T> child = current
+                        .childLocked()
+                        .computeIfAbsent(part, key -> new Topic<>(parent, key));
+                    current.updateWildcardChild(child, false);
+                    return child;
+                }
+            }
+            current = current.resolveCurrent();
+        }
+    }
+
+    private boolean hasDetachedAncestor() {
+        Topic<T> current = this;
+        while (current != null) {
+            if (current.subscribers == DETACHED) {
+                return true;
+            }
+            current = current.parent;
+        }
+        return false;
+    }
+
+    private Topic<T> resolveCurrent() {
+        Topic<T> root = this;
+        while (root.parent != null) {
+            root = root.parent;
+        }
+        return root.append(asStringArray());
+    }
+
+    private Topic<T> findCurrent() {
+        Topic<T> root = this;
+        while (root.parent != null) {
+            root = root.parent;
+        }
+        return root.getTopic(asStringArray()).orElse(null);
+    }
+
+    private void updateWildcardChild(Topic<T> child, boolean remove) {
         String part = child.part;
-        if (part.length() == 1 && part.charAt(0) == '*') {
-            if (isCurrentChild(part, child)) {
+        boolean star = part.length() == 1 && part.charAt(0) == '*';
+        boolean doubleStar = part.length() == 2 && part.charAt(0) == '*' && part.charAt(1) == '*';
+        if (star) {
+            if (remove) {
+                if (starChild == child) {
+                    starChild = null;
+                }
+            } else {
                 starChild = child;
             }
-        } else if (part.length() == 2 && part.charAt(0) == '*' && part.charAt(1) == '*') {
-            if (isCurrentChild(part, child)) {
+        } else if (doubleStar) {
+            if (remove) {
+                if (doubleStarChild == child) {
+                    doubleStarChild = null;
+                }
+            } else {
                 doubleStarChild = child;
             }
-        }
-    }
-
-    private boolean isCurrentChild(String part, Topic<T> child) {
-        ConcurrentMap<String, Topic<T>> children = this.child;
-        return children != null && children.get(part) == child;
-    }
-
-    private void removeCachedWildcardChild(Topic<T> child) {
-        if (starChild == child) {
-            starChild = null;
-        }
-        if (doubleStarChild == child) {
-            doubleStarChild = null;
         }
     }
 
@@ -284,59 +391,32 @@ public final class Topic<T> implements SeparatedCharSequence {
         setPart(parts[0]);
         if (parts.length > 1) {
             Topic<T> part = new Topic<>(this, parts[1]);
-            this.child().put(part.part, part);
-            tryCacheWildcardChild(part);
+            this.childLocked().put(part.part, part);
+            updateWildcardChild(part, false);
         }
-    }
-
-    private Topic<T> getOrDefault(String[] parts,
-                                  BiFunction<Topic<T>, String, Topic<T>> mapping,
-                                  boolean updateWildcardCache) {
-        int index = 0;
-        if (parts[0].isEmpty()) {
-            index = 1;
-        }
-        Topic<T> part = child().computeIfAbsent(parts[index], _topic -> mapping.apply(this, _topic));
-        if (updateWildcardCache && part != null) {
-            tryCacheWildcardChild(part);
-        }
-        for (int i = index + 1; i < parts.length && part != null; i++) {
-            Topic<T> parent = part;
-            part = part.child().computeIfAbsent(parts[i], _topic -> mapping.apply(parent, _topic));
-            if (updateWildcardCache && part != null) {
-                parent.tryCacheWildcardChild(part);
-            }
-        }
-        return part;
-    }
-
-    private Topic<T> getOrDefault(String topic,
-                                  BiFunction<Topic<T>, String, Topic<T>> mapping,
-                                  boolean updateWildcardCache) {
-        if (topic.charAt(0) == '/') {
-            topic = topic.substring(1);
-        }
-        String[] parts = TopicUtils.split(topic, true, true);
-        Topic<T> part = child().computeIfAbsent(parts[0], _topic -> mapping.apply(this, _topic));
-        if (updateWildcardCache && part != null) {
-            tryCacheWildcardChild(part);
-        }
-        for (int i = 1; i < parts.length && part != null; i++) {
-            Topic<T> parent = part;
-            part = part.child().computeIfAbsent(parts[i], _topic -> mapping.apply(parent, _topic));
-            if (updateWildcardCache && part != null) {
-                parent.tryCacheWildcardChild(part);
-            }
-        }
-        return part;
     }
 
     public Optional<Topic<T>> getTopic(String topic) {
-        return Optional.ofNullable(getOrDefault(topic, ((topicPart, s) -> null), false));
+        return getTopic(TopicUtils.split(topic, true, true));
     }
 
     public Optional<Topic<T>> getTopic(String[] topic) {
-        return Optional.ofNullable(getOrDefault(topic, ((topicPart, s) -> null), false));
+        if (topic == null || topic.length == 0) {
+            return Optional.of(this);
+        }
+        int index = topic[0].isEmpty() ? 1 : 0;
+        Topic<T> current = this;
+        for (int i = index; i < topic.length; i++) {
+            ConcurrentMap<String, Topic<T>> children = current.child;
+            if (children == null) {
+                return Optional.empty();
+            }
+            current = children.get(topic[i]);
+            if (current == null) {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(current);
     }
 
     public Flux<Topic<T>> findTopic(String topic) {
@@ -529,41 +609,57 @@ public final class Topic<T> implements SeparatedCharSequence {
     }
 
     public boolean cleanup(BiConsumer<Boolean, Topic<T>> handler) {
-        //清理订阅者
-        if (subscribers != null && subscribers.isEmpty()) {
-            synchronized (this) {
-                if (subscribers.isEmpty()) {
-                    subscribers = null;
-                }
-            }
-        }
-        //清理子节点
-        if (child != null) {
-            for (Map.Entry<String, Topic<T>> children : child.entrySet()) {
-                Topic<T> topic = children.getValue();
+        ConcurrentMap<String, Topic<T>> children = child;
+        if (children != null) {
+            for (Map.Entry<String, Topic<T>> entry : children.entrySet()) {
+                Topic<T> topic = entry.getValue();
                 boolean cleaned = topic.cleanup(handler);
                 if (cleaned) {
-                    if (child.remove(children.getKey(), topic)) {
-                        removeCachedWildcardChild(topic);
-                    }
+                    cleaned = removeChildIfEmpty(entry.getKey(), topic);
                 }
                 if (handler != null) {
                     handler.accept(cleaned, topic);
                 }
             }
+        }
 
-            if (child != null && child.isEmpty()) {
-                synchronized (this) {
-                    if (child.isEmpty()) {
-                        child = null;
-                        starChild = null;
-                        doubleStarChild = null;
-                    }
+        synchronized (this) {
+            ConcurrentMap<T, Integer> subscribers = this.subscribers;
+            if (subscribers != null && subscribers != DETACHED && subscribers.isEmpty()) {
+                this.subscribers = null;
+            }
+            children = child;
+            if (children != null && children.isEmpty()) {
+                child = null;
+                starChild = null;
+                doubleStarChild = null;
+            }
+            return (this.subscribers == null || this.subscribers == DETACHED) && child == null;
+        }
+    }
+
+    private boolean removeChildIfEmpty(String key, Topic<T> topic) {
+        synchronized (this) {
+            ConcurrentMap<String, Topic<T>> children = child;
+            if (children == null || children.get(key) != topic) {
+                return false;
+            }
+            synchronized (topic) {
+                if (!CollectionUtils.isEmpty(topic.subscribers) ||
+                    !CollectionUtils.isEmpty(topic.child)) {
+                    return false;
+                }
+                if (children.remove(key, topic)) {
+                    topic.subscribers = detachedMarker();
+                    topic.child = null;
+                    topic.starChild = null;
+                    topic.doubleStarChild = null;
+                    updateWildcardChild(topic, true);
+                    return true;
                 }
             }
         }
-        return CollectionUtils.isEmpty(subscribers) &&
-            CollectionUtils.isEmpty(child);
+        return false;
     }
 
     public boolean cleanup() {
@@ -571,12 +667,42 @@ public final class Topic<T> implements SeparatedCharSequence {
     }
 
     public void clean() {
-        unsubscribeAll();
-        if (child != null) {
-            child.values().forEach(Topic::clean);
-            child().clear();
+        Collection<Topic<T>> detached = detachChildren(false);
+        for (Topic<T> topic : detached) {
+            topic.cleanDetached();
+        }
+    }
+
+    private void cleanDetached() {
+        Collection<Topic<T>> detached = detachChildren(true);
+        for (Topic<T> topic : detached) {
+            topic.cleanDetached();
+        }
+    }
+
+    private Collection<Topic<T>> detachChildren(boolean detached) {
+        synchronized (this) {
+            boolean detachSelf = detached || hasDetachedAncestor();
+            ConcurrentMap<String, Topic<T>> children = child;
+            Collection<Topic<T>> snapshot;
+            if (children == null || children.isEmpty()) {
+                snapshot = Collections.emptyList();
+            } else {
+                snapshot = new ArrayList<>(children.values());
+                // 先发布直属子节点的 detached 状态，再断开 child Map，订阅可据此重建到当前树。
+                for (Topic<T> topic : snapshot) {
+                    synchronized (topic) {
+                        topic.subscribers = detachedMarker();
+                        topic.starChild = null;
+                        topic.doubleStarChild = null;
+                    }
+                }
+            }
+            subscribers = detachSelf ? detachedMarker() : null;
+            child = null;
             starChild = null;
             doubleStarChild = null;
+            return snapshot;
         }
     }
 
@@ -610,23 +736,18 @@ public final class Topic<T> implements SeparatedCharSequence {
     @Override
     public Topic<T> internInner() {
         this.part = RecyclerUtils.intern(this.part);
-        SharedPathString topics = this.topics;
-        if (topics != null) {
-            topics.internInner();
-        }
         return this;
     }
 
     @Override
     public int hashCode() {
-        if ($hash == 0) {
-            Topic<T> t = this;
-            while (t != null) {
-                $hash = 31 * $hash + t.part.hashCode();
-                t = t.parent;
-            }
+        int hash = 0;
+        Topic<T> topic = this;
+        while (topic != null) {
+            hash = 31 * hash + topic.part.hashCode();
+            topic = topic.parent;
         }
-        return $hash;
+        return hash;
     }
 
     @Override

--- a/src/main/java/org/jetlinks/core/topic/TopicFinder.java
+++ b/src/main/java/org/jetlinks/core/topic/TopicFinder.java
@@ -24,8 +24,56 @@ public class TopicFinder {
     private static final byte WILDCARD_SINGLE = 1;
     private static final byte WILDCARD_DOUBLE = 2;
 
-    private static final Recycler<Set<Topic<?>>> SHARED_SET =
-        Recycler.create(HashSet::new, Collection::clear, 256);
+    private static final int MAX_RETAINED_EMITTED = 4096;
+
+    private static final Recycler<ReusableTopicSet> SHARED_SET =
+        Recycler.create(ReusableTopicSet::new, ReusableTopicSet::reset, 256);
+
+    @SuppressWarnings("rawtypes")
+    private static final Consumer5<Consumer, Runnable, Object, Object, Topic> SIMPLE_SINK =
+        (sink, end, nil2, nil3, topic) -> sink.accept(topic);
+
+    @SuppressWarnings("rawtypes")
+    private static final Consumer4<Consumer, Runnable, Object, Object> SIMPLE_END =
+        (sink, end, nil2, nil3) -> end.run();
+
+    @SuppressWarnings("rawtypes")
+    private static final Consumer5<Object, BiConsumer, Consumer, Object, Topic> ONE_ARG_SINK =
+        (arg, sink, end, nil3, topic) -> sink.accept(arg, topic);
+
+    @SuppressWarnings("rawtypes")
+    private static final Consumer4<Object, BiConsumer, Consumer, Object> ONE_ARG_END =
+        (arg, sink, end, nil3) -> end.accept(arg);
+
+    @SuppressWarnings("rawtypes")
+    private static final Consumer5<Object, Object, Consumer3, BiConsumer, Topic> TWO_ARG_SINK =
+        (arg0, arg1, sink, end, topic) -> sink.accept(arg0, arg1, topic);
+
+    @SuppressWarnings("rawtypes")
+    private static final Consumer4<Object, Object, Consumer3, BiConsumer> TWO_ARG_END =
+        (arg0, arg1, sink, end) -> end.accept(arg0, arg1);
+
+    static final class ReusableTopicSet {
+
+        private Set<Topic<?>> values = newIdentitySet();
+
+        @SuppressWarnings("unchecked")
+        <T> Set<Topic<T>> values() {
+            return (Set<Topic<T>>) (Set<?>) values;
+        }
+
+        void reset() {
+            if (values.size() > MAX_RETAINED_EMITTED) {
+                values = newIdentitySet();
+            } else {
+                values.clear();
+            }
+        }
+
+        private static Set<Topic<?>> newIdentitySet() {
+            return Collections.newSetFromMap(new IdentityHashMap<>());
+        }
+    }
 
     /**
      * 使用 DFS（深度优先）算法搜索匹配 topic 的节点.
@@ -36,6 +84,7 @@ public class TopicFinder {
      * @param end   搜索结束回调
      * @param <T>   订阅者类型
      */
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T> void find(Topic<T> root,
                                 String topic,
                                 Consumer<Topic<T>> sink,
@@ -47,11 +96,12 @@ public class TopicFinder {
         }
 
         find(root, splitTopic(topic),
-             null, null, null, null,
-             (a, b, c, d, t) -> sink.accept(t),
-             (a, b, c, d) -> end.run());
+             sink, end, null, null,
+             (Consumer5) SIMPLE_SINK,
+             (Consumer4) SIMPLE_END);
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T> void find(Topic<T> root,
                                 CharSequence topic,
                                 Consumer<Topic<T>> sink,
@@ -59,7 +109,7 @@ public class TopicFinder {
         if (topic instanceof SeparatedCharSequence) {
             find(root, (SeparatedCharSequence) topic,
                  null, null, null, null,
-                 (a, b, c, d, t) -> sink.accept(t),
+                 (a, b, c, d, found) -> sink.accept(found),
                  (a, b, c, d) -> end.run());
         } else {
             find(root, topic.toString(), sink, end);
@@ -80,16 +130,10 @@ public class TopicFinder {
     }
 
     private static String[] splitTopic(String topic) {
-        String[] topics = TopicUtils.split(topic, false, false);
-        if (topic.charAt(0) != '/') {
-            String[] newTopics = new String[topics.length + 1];
-            newTopics[0] = "";
-            System.arraycopy(topics, 0, newTopics, 1, topics.length);
-            topics = newTopics;
-        }
-        return topics;
+        return TopicUtils.split(topic, false, false);
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T, A, B> void find(Topic<T> root,
                                       CharSequence topic,
                                       A arg1,
@@ -97,13 +141,13 @@ public class TopicFinder {
                                       Consumer3<A, B, Topic<T>> sink,
                                       BiConsumer<A, B> end) {
         if (topic instanceof SeparatedCharSequence) {
-            find(root, (SeparatedCharSequence) topic, arg1, arg2, null, null,
-                 (a1, b, nil2, nil3, _topic) -> sink.accept(a1, b, _topic),
-                 (a1, b, nil2, nil3) -> end.accept(a1, b));
+            find(root, (SeparatedCharSequence) topic, arg1, arg2, sink, end,
+                 (Consumer5) TWO_ARG_SINK,
+                 (Consumer4) TWO_ARG_END);
         } else {
-            find(root, topic.toString(), arg1, arg2, null, null,
-                 (a1, b, nil2, nil3, _topic) -> sink.accept(a1, b, _topic),
-                 (a1, b, nil2, nil3) -> end.accept(a1, b));
+            find(root, topic.toString(), arg1, arg2, sink, end,
+                 (Consumer5) TWO_ARG_SINK,
+                 (Consumer4) TWO_ARG_END);
         }
     }
 
@@ -119,20 +163,20 @@ public class TopicFinder {
         }
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T, A> void find(Topic<T> root,
                                    CharSequence topic,
                                    A arg1,
                                    BiConsumer<A, Topic<T>> sink,
                                    Consumer<A> end) {
         if (topic instanceof SeparatedCharSequence) {
-            find(root, (SeparatedCharSequence) topic, arg1, null, null, null,
-                 (a1, nil1, nil2, nil3, _topic) -> sink.accept(a1, _topic),
-                 (a1, nil1, nil2, nil3) -> end.accept(a1));
+            find(root, (SeparatedCharSequence) topic, arg1, sink, end, null,
+                 (Consumer5) ONE_ARG_SINK,
+                 (Consumer4) ONE_ARG_END);
         } else {
-            find(root, TopicUtils.split(topic.toString(), false, false),
-                 arg1, null, null, null,
-                 (a1, nil1, nil2, nil3, _topic) -> sink.accept(a1, _topic),
-                 (a1, nil1, nil2, nil3) -> end.accept(a1));
+            find(root, topic.toString(), arg1, sink, end, null,
+                 (Consumer5) ONE_ARG_SINK,
+                 (Consumer4) ONE_ARG_END);
         }
     }
 
@@ -141,24 +185,25 @@ public class TopicFinder {
                                                         ARG0 arg0, ARG1 arg1, ARG2 arg2, ARG3 arg3,
                                                         Consumer5<ARG0, ARG1, ARG2, ARG3, Topic<T>> sink,
                                                         Consumer4<ARG0, ARG1, ARG2, ARG3> end) {
+        int first = firstTopicIndex(topic);
         byte wildcardMode = detectWildcardMode(topic);
         // 精确 topic 直接走无分支路径, 避免通配符 DFS 的额外递归和集合开销.
         if (wildcardMode == WILDCARD_NONE) {
-            findExactInner(topic, 1, root, arg0, arg1, arg2, arg3, sink);
+            findExactInner(topic, first, root, arg0, arg1, arg2, arg3, sink);
             end.accept(arg0, arg1, arg2, arg3);
             return;
         }
         if (wildcardMode == WILDCARD_DOUBLE) {
-            Recyclable<Set<Topic<T>>> recyclableSet = (Recyclable) SHARED_SET.take(true);
+            Recyclable<ReusableTopicSet> recyclableSet = SHARED_SET.take(true);
             try {
-                findDFSInner(topic, 1, root, recyclableSet.get(),
+                findDFSInner(topic, first, root, recyclableSet.get().values(),
                              arg0, arg1, arg2, arg3, sink);
             } finally {
                 recyclableSet.recycle();
                 end.accept(arg0, arg1, arg2, arg3);
             }
         } else {
-            findDFSInner(topic, 1, root, null,
+            findDFSInner(topic, first, root, null,
                          arg0, arg1, arg2, arg3, sink);
             end.accept(arg0, arg1, arg2, arg3);
         }
@@ -170,27 +215,40 @@ public class TopicFinder {
                                                         Consumer5<ARG0, ARG1, ARG2, ARG3, Topic<T>> sink,
                                                         Consumer4<ARG0, ARG1, ARG2, ARG3> end) {
 
+        int first = firstTopicIndex(topicParts);
         byte wildcardMode = detectWildcardMode(topicParts);
         // 精确 topic 直接走无分支路径, 避免通配符 DFS 的额外递归和集合开销.
         if (wildcardMode == WILDCARD_NONE) {
-            findExactInner(topicParts, 1, root, arg0, arg1, arg2, arg3, sink);
+            findExactInner(topicParts, first, root, arg0, arg1, arg2, arg3, sink);
             end.accept(arg0, arg1, arg2, arg3);
             return;
         }
         if (wildcardMode == WILDCARD_DOUBLE) {
-            Recyclable<Set<Topic<T>>> recyclableSet = (Recyclable) SHARED_SET.take(true);
+            Recyclable<ReusableTopicSet> recyclableSet = SHARED_SET.take(true);
             try {
-                findDFSInner(topicParts, 1, root, recyclableSet.get(),
+                findDFSInner(topicParts, first, root, recyclableSet.get().values(),
                              arg0, arg1, arg2, arg3, sink);
             } finally {
                 recyclableSet.recycle();
                 end.accept(arg0, arg1, arg2, arg3);
             }
         } else {
-            findDFSInner(topicParts, 1, root, null,
+            findDFSInner(topicParts, first, root, null,
                          arg0, arg1, arg2, arg3, sink);
             end.accept(arg0, arg1, arg2, arg3);
         }
+    }
+
+    private static int firstTopicIndex(String[] parts) {
+        return parts.length > 0 && parts[0].isEmpty() ? 1 : 0;
+    }
+
+    private static int firstTopicIndex(SeparatedCharSequence parts) {
+        if (parts.size() == 0) {
+            return 0;
+        }
+        CharSequence first = parts.get(0);
+        return first == null || first.length() == 0 ? 1 : 0;
     }
 
     private static byte detectWildcardMode(String[] parts) {

--- a/src/main/java/org/jetlinks/core/topic/TopicFinder.java
+++ b/src/main/java/org/jetlinks/core/topic/TopicFinder.java
@@ -20,6 +20,10 @@ import java.util.function.Consumer;
  */
 public class TopicFinder {
 
+    private static final byte WILDCARD_NONE = 0;
+    private static final byte WILDCARD_SINGLE = 1;
+    private static final byte WILDCARD_DOUBLE = 2;
+
     private static final Recycler<Set<Topic<?>>> SHARED_SET =
         Recycler.create(HashSet::new, Collection::clear, 256);
 
@@ -137,13 +141,14 @@ public class TopicFinder {
                                                         ARG0 arg0, ARG1 arg1, ARG2 arg2, ARG3 arg3,
                                                         Consumer5<ARG0, ARG1, ARG2, ARG3, Topic<T>> sink,
                                                         Consumer4<ARG0, ARG1, ARG2, ARG3> end) {
+        byte wildcardMode = detectWildcardMode(topic);
         // 精确 topic 直接走无分支路径, 避免通配符 DFS 的额外递归和集合开销.
-        if (!searchHasWildcard(topic)) {
+        if (wildcardMode == WILDCARD_NONE) {
             findExactInner(topic, 1, root, arg0, arg1, arg2, arg3, sink);
             end.accept(arg0, arg1, arg2, arg3);
             return;
         }
-        if (searchHasDoubleWildcard(topic)) {
+        if (wildcardMode == WILDCARD_DOUBLE) {
             Recyclable<Set<Topic<T>>> recyclableSet = (Recyclable) SHARED_SET.take(true);
             try {
                 findDFSInner(topic, 1, root, recyclableSet.get(),
@@ -165,13 +170,14 @@ public class TopicFinder {
                                                         Consumer5<ARG0, ARG1, ARG2, ARG3, Topic<T>> sink,
                                                         Consumer4<ARG0, ARG1, ARG2, ARG3> end) {
 
+        byte wildcardMode = detectWildcardMode(topicParts);
         // 精确 topic 直接走无分支路径, 避免通配符 DFS 的额外递归和集合开销.
-        if (!searchHasWildcard(topicParts)) {
+        if (wildcardMode == WILDCARD_NONE) {
             findExactInner(topicParts, 1, root, arg0, arg1, arg2, arg3, sink);
             end.accept(arg0, arg1, arg2, arg3);
             return;
         }
-        if (searchHasDoubleWildcard(topicParts)) {
+        if (wildcardMode == WILDCARD_DOUBLE) {
             Recyclable<Set<Topic<T>>> recyclableSet = (Recyclable) SHARED_SET.take(true);
             try {
                 findDFSInner(topicParts, 1, root, recyclableSet.get(),
@@ -187,44 +193,32 @@ public class TopicFinder {
         }
     }
 
-    private static boolean searchHasDoubleWildcard(String[] parts) {
+    private static byte detectWildcardMode(String[] parts) {
+        byte mode = WILDCARD_NONE;
         for (String p : parts) {
-            if ("**".equals(p)) return true;
-        }
-        return false;
-    }
-
-    private static boolean searchHasWildcard(String[] parts) {
-        for (String p : parts) {
-            if ("*".equals(p) || "**".equals(p)) {
-                return true;
+            if ("*".equals(p)) {
+                mode = WILDCARD_SINGLE;
+            } else if ("**".equals(p)) {
+                return WILDCARD_DOUBLE;
             }
         }
-        return false;
+        return mode;
     }
 
-    private static boolean searchHasDoubleWildcard(SeparatedCharSequence parts) {
-        for (int i = 0, n = parts.size(); i < n; i++) {
-            CharSequence c = parts.get(i);
-            if (c != null && "**".contentEquals(c)) return true;
-        }
-        return false;
-    }
-
-    private static boolean searchHasWildcard(SeparatedCharSequence parts) {
+    private static byte detectWildcardMode(SeparatedCharSequence parts) {
+        byte mode = WILDCARD_NONE;
         for (int i = 0, n = parts.size(); i < n; i++) {
             CharSequence c = parts.get(i);
             if (c == null) {
                 continue;
             }
             if (c.length() == 1 && c.charAt(0) == '*') {
-                return true;
-            }
-            if (c.length() == 2 && c.charAt(0) == '*' && c.charAt(1) == '*') {
-                return true;
+                mode = WILDCARD_SINGLE;
+            } else if (c.length() == 2 && c.charAt(0) == '*' && c.charAt(1) == '*') {
+                return WILDCARD_DOUBLE;
             }
         }
-        return false;
+        return mode;
     }
 
     private static String topicPart(CharSequence part) {
@@ -240,12 +234,9 @@ public class TopicFinder {
 
         if (idx >= st.length) {
             sink.accept(arg0, arg1, arg2, arg3, node);
-            Map<String, Topic<T>> ch = node.getChildrenMap();
-            if (ch != null) {
-                Topic<T> dstar = ch.get("**");
-                if (dstar != null) {
-                    findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
-                }
+            Topic<T> dstar = node.getDoubleStarChild();
+            if (dstar != null) {
+                findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
             }
             return;
         }
@@ -262,11 +253,11 @@ public class TopicFinder {
             if (exact != null) {
                 findExactInner(st, idx + 1, exact, arg0, arg1, arg2, arg3, sink);
             }
-            Topic<T> star = ch.get("*");
+            Topic<T> star = node.getStarChild();
             if (star != null) {
                 findExactInner(st, idx + 1, star, arg0, arg1, arg2, arg3, sink);
             }
-            Topic<T> innerDstar = ch.get("**");
+            Topic<T> innerDstar = node.getDoubleStarChild();
             if (innerDstar != null) {
                 findExactInner(st, idx, innerDstar, arg0, arg1, arg2, arg3, sink);
             }
@@ -282,11 +273,11 @@ public class TopicFinder {
         if (exact != null) {
             findExactInner(st, idx + 1, exact, arg0, arg1, arg2, arg3, sink);
         }
-        Topic<T> star = children.get("*");
+        Topic<T> star = node.getStarChild();
         if (star != null) {
             findExactInner(st, idx + 1, star, arg0, arg1, arg2, arg3, sink);
         }
-        Topic<T> dstar = children.get("**");
+        Topic<T> dstar = node.getDoubleStarChild();
         if (dstar != null) {
             findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
         }
@@ -303,12 +294,9 @@ public class TopicFinder {
 
         if (idx >= stSize) {
             sink.accept(arg0, arg1, arg2, arg3, node);
-            Map<String, Topic<T>> ch = node.getChildrenMap();
-            if (ch != null) {
-                Topic<T> dstar = ch.get("**");
-                if (dstar != null) {
-                    findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
-                }
+            Topic<T> dstar = node.getDoubleStarChild();
+            if (dstar != null) {
+                findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
             }
             return;
         }
@@ -325,11 +313,11 @@ public class TopicFinder {
             if (exact != null) {
                 findExactInner(st, idx + 1, exact, arg0, arg1, arg2, arg3, sink);
             }
-            Topic<T> star = ch.get("*");
+            Topic<T> star = node.getStarChild();
             if (star != null) {
                 findExactInner(st, idx + 1, star, arg0, arg1, arg2, arg3, sink);
             }
-            Topic<T> innerDstar = ch.get("**");
+            Topic<T> innerDstar = node.getDoubleStarChild();
             if (innerDstar != null) {
                 findExactInner(st, idx, innerDstar, arg0, arg1, arg2, arg3, sink);
             }
@@ -345,11 +333,11 @@ public class TopicFinder {
         if (exact != null) {
             findExactInner(st, idx + 1, exact, arg0, arg1, arg2, arg3, sink);
         }
-        Topic<T> star = children.get("*");
+        Topic<T> star = node.getStarChild();
         if (star != null) {
             findExactInner(st, idx + 1, star, arg0, arg1, arg2, arg3, sink);
         }
-        Topic<T> dstar = children.get("**");
+        Topic<T> dstar = node.getDoubleStarChild();
         if (dstar != null) {
             findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
         }
@@ -367,12 +355,9 @@ public class TopicFinder {
             if (emitted == null || emitted.add(node)) {
                 sink.accept(arg0, arg1, arg2, arg3, node);
             }
-            Map<String, Topic<T>> ch = node.getChildrenMap();
-            if (ch != null) {
-                Topic<T> dstar = ch.get("**");
-                if (dstar != null) {
-                    findDFSInner(st, idx, dstar, emitted, arg0, arg1, arg2, arg3, sink);
-                }
+            Topic<T> dstar = node.getDoubleStarChild();
+            if (dstar != null) {
+                findDFSInner(st, idx, dstar, emitted, arg0, arg1, arg2, arg3, sink);
             }
             return;
         }
@@ -394,9 +379,9 @@ public class TopicFinder {
             } else {
                 Topic<T> exact = ch.get(searchPart);
                 if (exact != null) findDFSInner(st, idx + 1, exact, emitted, arg0, arg1, arg2, arg3, sink);
-                Topic<T> star = ch.get("*");
+                Topic<T> star = node.getStarChild();
                 if (star != null) findDFSInner(st, idx + 1, star, emitted, arg0, arg1, arg2, arg3, sink);
-                Topic<T> innerDstar = ch.get("**");
+                Topic<T> innerDstar = node.getDoubleStarChild();
                 if (innerDstar != null) findDFSInner(st, idx, innerDstar, emitted, arg0, arg1, arg2, arg3, sink);
             }
             return;
@@ -424,9 +409,9 @@ public class TopicFinder {
         } else {
             Topic<T> exact = children.get(searchPart);
             if (exact != null) findDFSInner(st, idx + 1, exact, emitted, arg0, arg1, arg2, arg3, sink);
-            Topic<T> star = children.get("*");
+            Topic<T> star = node.getStarChild();
             if (star != null) findDFSInner(st, idx + 1, star, emitted, arg0, arg1, arg2, arg3, sink);
-            Topic<T> dstar = children.get("**");
+            Topic<T> dstar = node.getDoubleStarChild();
             if (dstar != null) findDFSInner(st, idx, dstar, emitted, arg0, arg1, arg2, arg3, sink);
         }
     }
@@ -445,12 +430,9 @@ public class TopicFinder {
             if (emitted == null || emitted.add(node)) {
                 sink.accept(arg0, arg1, arg2, arg3, node);
             }
-            Map<String, Topic<T>> ch = node.getChildrenMap();
-            if (ch != null) {
-                Topic<T> dstar = ch.get("**");
-                if (dstar != null) {
-                    findDFSInner(st, idx, dstar, emitted, arg0, arg1, arg2, arg3, sink);
-                }
+            Topic<T> dstar = node.getDoubleStarChild();
+            if (dstar != null) {
+                findDFSInner(st, idx, dstar, emitted, arg0, arg1, arg2, arg3, sink);
             }
             return;
         }
@@ -472,9 +454,9 @@ public class TopicFinder {
             } else {
                 Topic<T> exact = ch.get(searchPart);
                 if (exact != null) findDFSInner(st, idx + 1, exact, emitted, arg0, arg1, arg2, arg3, sink);
-                Topic<T> star = ch.get("*");
+                Topic<T> star = node.getStarChild();
                 if (star != null) findDFSInner(st, idx + 1, star, emitted, arg0, arg1, arg2, arg3, sink);
-                Topic<T> innerDstar = ch.get("**");
+                Topic<T> innerDstar = node.getDoubleStarChild();
                 if (innerDstar != null) findDFSInner(st, idx, innerDstar, emitted, arg0, arg1, arg2, arg3, sink);
             }
             return;
@@ -502,9 +484,9 @@ public class TopicFinder {
         } else {
             Topic<T> exact = children.get(searchPart);
             if (exact != null) findDFSInner(st, idx + 1, exact, emitted, arg0, arg1, arg2, arg3, sink);
-            Topic<T> star = children.get("*");
+            Topic<T> star = node.getStarChild();
             if (star != null) findDFSInner(st, idx + 1, star, emitted, arg0, arg1, arg2, arg3, sink);
-            Topic<T> dstar = children.get("**");
+            Topic<T> dstar = node.getDoubleStarChild();
             if (dstar != null) findDFSInner(st, idx, dstar, emitted, arg0, arg1, arg2, arg3, sink);
         }
     }

--- a/src/main/java/org/jetlinks/core/topic/TopicFinder.java
+++ b/src/main/java/org/jetlinks/core/topic/TopicFinder.java
@@ -137,6 +137,12 @@ public class TopicFinder {
                                                         ARG0 arg0, ARG1 arg1, ARG2 arg2, ARG3 arg3,
                                                         Consumer5<ARG0, ARG1, ARG2, ARG3, Topic<T>> sink,
                                                         Consumer4<ARG0, ARG1, ARG2, ARG3> end) {
+        // 精确 topic 直接走无分支路径, 避免通配符 DFS 的额外递归和集合开销.
+        if (!searchHasWildcard(topic)) {
+            findExactInner(topic, 1, root, arg0, arg1, arg2, arg3, sink);
+            end.accept(arg0, arg1, arg2, arg3);
+            return;
+        }
         if (searchHasDoubleWildcard(topic)) {
             Recyclable<Set<Topic<T>>> recyclableSet = (Recyclable) SHARED_SET.take(true);
             try {
@@ -159,6 +165,12 @@ public class TopicFinder {
                                                         Consumer5<ARG0, ARG1, ARG2, ARG3, Topic<T>> sink,
                                                         Consumer4<ARG0, ARG1, ARG2, ARG3> end) {
 
+        // 精确 topic 直接走无分支路径, 避免通配符 DFS 的额外递归和集合开销.
+        if (!searchHasWildcard(topicParts)) {
+            findExactInner(topicParts, 1, root, arg0, arg1, arg2, arg3, sink);
+            end.accept(arg0, arg1, arg2, arg3);
+            return;
+        }
         if (searchHasDoubleWildcard(topicParts)) {
             Recyclable<Set<Topic<T>>> recyclableSet = (Recyclable) SHARED_SET.take(true);
             try {
@@ -182,12 +194,165 @@ public class TopicFinder {
         return false;
     }
 
+    private static boolean searchHasWildcard(String[] parts) {
+        for (String p : parts) {
+            if ("*".equals(p) || "**".equals(p)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static boolean searchHasDoubleWildcard(SeparatedCharSequence parts) {
         for (int i = 0, n = parts.size(); i < n; i++) {
             CharSequence c = parts.get(i);
             if (c != null && "**".contentEquals(c)) return true;
         }
         return false;
+    }
+
+    private static boolean searchHasWildcard(SeparatedCharSequence parts) {
+        for (int i = 0, n = parts.size(); i < n; i++) {
+            CharSequence c = parts.get(i);
+            if (c == null) {
+                continue;
+            }
+            if (c.length() == 1 && c.charAt(0) == '*') {
+                return true;
+            }
+            if (c.length() == 2 && c.charAt(0) == '*' && c.charAt(1) == '*') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String topicPart(CharSequence part) {
+        return part instanceof String ? (String) part : String.valueOf(part);
+    }
+
+    private static <T, ARG0, ARG1, ARG2, ARG3> void findExactInner(
+        final String[] st,
+        final int idx,
+        final Topic<T> node,
+        final ARG0 arg0, final ARG1 arg1, final ARG2 arg2, final ARG3 arg3,
+        final Consumer5<ARG0, ARG1, ARG2, ARG3, Topic<T>> sink) {
+
+        if (idx >= st.length) {
+            sink.accept(arg0, arg1, arg2, arg3, node);
+            Map<String, Topic<T>> ch = node.getChildrenMap();
+            if (ch != null) {
+                Topic<T> dstar = ch.get("**");
+                if (dstar != null) {
+                    findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
+                }
+            }
+            return;
+        }
+
+        String searchPart = st[idx];
+
+        if ("**".equals(node.getPart())) {
+            findExactInner(st, idx + 1, node, arg0, arg1, arg2, arg3, sink);
+            Map<String, Topic<T>> ch = node.getChildrenMap();
+            if (ch == null) {
+                return;
+            }
+            Topic<T> exact = ch.get(searchPart);
+            if (exact != null) {
+                findExactInner(st, idx + 1, exact, arg0, arg1, arg2, arg3, sink);
+            }
+            Topic<T> star = ch.get("*");
+            if (star != null) {
+                findExactInner(st, idx + 1, star, arg0, arg1, arg2, arg3, sink);
+            }
+            Topic<T> innerDstar = ch.get("**");
+            if (innerDstar != null) {
+                findExactInner(st, idx, innerDstar, arg0, arg1, arg2, arg3, sink);
+            }
+            return;
+        }
+
+        Map<String, Topic<T>> children = node.getChildrenMap();
+        if (children == null) {
+            return;
+        }
+
+        Topic<T> exact = children.get(searchPart);
+        if (exact != null) {
+            findExactInner(st, idx + 1, exact, arg0, arg1, arg2, arg3, sink);
+        }
+        Topic<T> star = children.get("*");
+        if (star != null) {
+            findExactInner(st, idx + 1, star, arg0, arg1, arg2, arg3, sink);
+        }
+        Topic<T> dstar = children.get("**");
+        if (dstar != null) {
+            findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
+        }
+    }
+
+    private static <T, ARG0, ARG1, ARG2, ARG3> void findExactInner(
+        final SeparatedCharSequence st,
+        final int idx,
+        final Topic<T> node,
+        final ARG0 arg0, final ARG1 arg1, final ARG2 arg2, final ARG3 arg3,
+        final Consumer5<ARG0, ARG1, ARG2, ARG3, Topic<T>> sink) {
+
+        final int stSize = st.size();
+
+        if (idx >= stSize) {
+            sink.accept(arg0, arg1, arg2, arg3, node);
+            Map<String, Topic<T>> ch = node.getChildrenMap();
+            if (ch != null) {
+                Topic<T> dstar = ch.get("**");
+                if (dstar != null) {
+                    findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
+                }
+            }
+            return;
+        }
+
+        String searchPart = topicPart(st.get(idx));
+
+        if ("**".equals(node.getPart())) {
+            findExactInner(st, idx + 1, node, arg0, arg1, arg2, arg3, sink);
+            Map<String, Topic<T>> ch = node.getChildrenMap();
+            if (ch == null) {
+                return;
+            }
+            Topic<T> exact = ch.get(searchPart);
+            if (exact != null) {
+                findExactInner(st, idx + 1, exact, arg0, arg1, arg2, arg3, sink);
+            }
+            Topic<T> star = ch.get("*");
+            if (star != null) {
+                findExactInner(st, idx + 1, star, arg0, arg1, arg2, arg3, sink);
+            }
+            Topic<T> innerDstar = ch.get("**");
+            if (innerDstar != null) {
+                findExactInner(st, idx, innerDstar, arg0, arg1, arg2, arg3, sink);
+            }
+            return;
+        }
+
+        Map<String, Topic<T>> children = node.getChildrenMap();
+        if (children == null) {
+            return;
+        }
+
+        Topic<T> exact = children.get(searchPart);
+        if (exact != null) {
+            findExactInner(st, idx + 1, exact, arg0, arg1, arg2, arg3, sink);
+        }
+        Topic<T> star = children.get("*");
+        if (star != null) {
+            findExactInner(st, idx + 1, star, arg0, arg1, arg2, arg3, sink);
+        }
+        Topic<T> dstar = children.get("**");
+        if (dstar != null) {
+            findExactInner(st, idx, dstar, arg0, arg1, arg2, arg3, sink);
+        }
     }
 
     private static <T, ARG0, ARG1, ARG2, ARG3> void findDFSInner(

--- a/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmark.java
+++ b/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmark.java
@@ -19,6 +19,7 @@ import reactor.function.Consumer4;
 import reactor.function.Consumer5;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * TopicFinder 精确、miss 与搜索侧 wildcard 路径的微基准。
@@ -47,7 +48,7 @@ public class TopicFinderJmhBenchmark {
         };
 
     @State(Scope.Thread)
-    public static class TopicFinderState {
+    public static class TopicFinderState implements Consumer<Topic<Integer>>, Runnable {
 
         @Param({"EXACT_ONLY", "MIXED"})
         String treeType;
@@ -119,6 +120,21 @@ public class TopicFinderJmhBenchmark {
             root.findTopic(topic, this, null, null, null, MATCH_SINK, END_SINK);
             return matches;
         }
+
+        private int findUsingAdapter(CharSequence topic) {
+            matches = 0;
+            root.findTopic(topic, this, this);
+            return matches;
+        }
+
+        @Override
+        public void accept(Topic<Integer> topic) {
+            matches += topic.getSubscribers().size();
+        }
+
+        @Override
+        public void run() {
+        }
     }
 
     @Benchmark
@@ -129,6 +145,16 @@ public class TopicFinderJmhBenchmark {
     @Benchmark
     public int exactSeparatedFind(TopicFinderState state) {
         return state.find(state.exactSeqSamples[state.nextIndex()]);
+    }
+
+    @Benchmark
+    public int exactStringAdapterFind(TopicFinderState state) {
+        return state.findUsingAdapter(state.exactTopicSamples[state.nextIndex()]);
+    }
+
+    @Benchmark
+    public int exactSeparatedAdapterFind(TopicFinderState state) {
+        return state.findUsingAdapter(state.exactSeqSamples[state.nextIndex()]);
     }
 
     @Benchmark

--- a/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmark.java
+++ b/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmark.java
@@ -10,99 +10,144 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
+import reactor.function.Consumer4;
+import reactor.function.Consumer5;
 
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 /**
- * 针对 TopicFinder 的精确查找与 wildcard 查找微基准.
+ * TopicFinder 精确、miss 与搜索侧 wildcard 路径的微基准。
+ *
+ * 基准使用确定性样本游标，避免把随机数生成成本计入查找；EXACT_ONLY 与 MIXED
+ * 分别隔离纯精确树和包含订阅侧 * / ** 的真实混合树。
  */
-@BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.SECONDS)
-@State(Scope.Benchmark)
-@Warmup(iterations = 1, time = 3)
-@Measurement(iterations = 2, time = 5)
-@Fork(value = 0, jvmArgs = {"-Xms2g", "-Xmx2g", "-XX:+UseG1GC"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3, jvmArgs = {"-Xms2g", "-Xmx2g", "-XX:+UseG1GC"})
 public class TopicFinderJmhBenchmark {
 
     private static final int TENANT_COUNT = 256;
     private static final int PRODUCT_COUNT = 128;
+    private static final int SAMPLE_COUNT = 1024;
+    private static final int SAMPLE_MASK = SAMPLE_COUNT - 1;
     private static final String EXACT_SUFFIX = "/message/property/report";
-    private static final String WILDCARD_SUFFIX = "/message/*";
 
-    @State(Scope.Benchmark)
+    private static final Consumer5<TopicFinderState, Object, Object, Object, Topic<Integer>> MATCH_SINK =
+        (state, ignore1, ignore2, ignore3, topic) -> state.matches += topic.getSubscribers().size();
+
+    private static final Consumer4<TopicFinderState, Object, Object, Object> END_SINK =
+        (state, ignore1, ignore2, ignore3) -> {
+        };
+
+    @State(Scope.Thread)
     public static class TopicFinderState {
-        Topic<Integer> root = Topic.createRoot();
-        String[] exactTopicSamples = new String[1024];
-        SeparatedCharSequence[] exactSeqSamples = new SeparatedCharSequence[1024];
-        String[] wildcardTopicSamples = new String[1024];
-        SeparatedCharSequence[] wildcardSeqSamples = new SeparatedCharSequence[1024];
+
+        @Param({"EXACT_ONLY", "MIXED"})
+        String treeType;
+
+        private Topic<Integer> root;
+        private String[] exactTopicSamples;
+        private SeparatedCharSequence[] exactSeqSamples;
+        private String[] missTopicSamples;
+        private SeparatedCharSequence[] missSeqSamples;
+        private String[] wildcardTopicSamples;
+        private SeparatedCharSequence[] wildcardSeqSamples;
+        private int cursor;
+        private int matches;
 
         @Setup(Level.Trial)
         public void init() {
+            root = Topic.createRoot();
+            exactTopicSamples = new String[SAMPLE_COUNT];
+            exactSeqSamples = new SeparatedCharSequence[SAMPLE_COUNT];
+            missTopicSamples = new String[SAMPLE_COUNT];
+            missSeqSamples = new SeparatedCharSequence[SAMPLE_COUNT];
+            wildcardTopicSamples = new String[SAMPLE_COUNT];
+            wildcardSeqSamples = new SeparatedCharSequence[SAMPLE_COUNT];
+
+            boolean mixed = "MIXED".equals(treeType);
             for (int tenant = 0; tenant < TENANT_COUNT; tenant++) {
-                root.append("/tenant/" + tenant + "/device/**").subscribe(tenant);
+                if (mixed) {
+                    root.append("/tenant/" + tenant + "/device/**").subscribe(tenant);
+                }
                 for (int product = 0; product < PRODUCT_COUNT; product++) {
                     root.append("/tenant/" + tenant + "/device/" + product + EXACT_SUFFIX)
                         .subscribe(product);
-                    root.append("/tenant/" + tenant + "/device/*" + EXACT_SUFFIX)
-                        .subscribe(product);
-                    root.append("/tenant/" + tenant + "/device/" + product + WILDCARD_SUFFIX)
-                        .subscribe(product);
+                    if (mixed) {
+                        root.append("/tenant/" + tenant + "/device/*" + EXACT_SUFFIX)
+                            .subscribe(product);
+                        root.append("/tenant/" + tenant + "/device/" + product + "/message/*")
+                            .subscribe(product);
+                    }
                 }
             }
-            ThreadLocalRandom random = ThreadLocalRandom.current();
-            for (int i = 0; i < exactTopicSamples.length; i++) {
-                int tenant = random.nextInt(TENANT_COUNT);
-                int product = random.nextInt(PRODUCT_COUNT);
+
+            for (int i = 0; i < SAMPLE_COUNT; i++) {
+                int tenant = i & (TENANT_COUNT - 1);
+                int product = (i * 31) & (PRODUCT_COUNT - 1);
                 String exact = "/tenant/" + tenant + "/device/" + product + EXACT_SUFFIX;
-                String wildcard = "/tenant/" + tenant + "/device/" + product + "/message/*";
+                String miss = "/tenant/" + tenant + "/device/missing-" + i + EXACT_SUFFIX;
+                String wildcard = "/tenant/" + tenant + "/device/*" + EXACT_SUFFIX;
                 exactTopicSamples[i] = exact;
                 exactSeqSamples[i] = SharedPathString.of(exact);
+                missTopicSamples[i] = miss;
+                missSeqSamples[i] = SharedPathString.of(miss);
                 wildcardTopicSamples[i] = wildcard;
                 wildcardSeqSamples[i] = SharedPathString.of(wildcard);
             }
         }
+
+        private int nextIndex() {
+            return cursor++ & SAMPLE_MASK;
+        }
+
+        private int find(String topic) {
+            matches = 0;
+            root.findTopic(topic, this, null, null, null, MATCH_SINK, END_SINK);
+            return matches;
+        }
+
+        private int find(SeparatedCharSequence topic) {
+            matches = 0;
+            root.findTopic(topic, this, null, null, null, MATCH_SINK, END_SINK);
+            return matches;
+        }
     }
 
     @Benchmark
-    public void exactStringFind(TopicFinderState state, Blackhole blackhole) {
-        String topic = state.exactTopicSamples[ThreadLocalRandom.current().nextInt(state.exactTopicSamples.length)];
-        state.root.findTopic(topic,
-                            node -> blackhole.consume(node.getSubscribers()),
-                            () -> {
-                            });
+    public int exactStringFind(TopicFinderState state) {
+        return state.find(state.exactTopicSamples[state.nextIndex()]);
     }
 
     @Benchmark
-    public void exactSeparatedFind(TopicFinderState state, Blackhole blackhole) {
-        SeparatedCharSequence topic = state.exactSeqSamples[ThreadLocalRandom.current().nextInt(state.exactSeqSamples.length)];
-        state.root.findTopic(topic,
-                            node -> blackhole.consume(node.getSubscribers()),
-                            () -> {
-                            });
+    public int exactSeparatedFind(TopicFinderState state) {
+        return state.find(state.exactSeqSamples[state.nextIndex()]);
     }
 
     @Benchmark
-    public void wildcardStringFind(TopicFinderState state, Blackhole blackhole) {
-        String topic = state.wildcardTopicSamples[ThreadLocalRandom.current().nextInt(state.wildcardTopicSamples.length)];
-        state.root.findTopic(topic,
-                            node -> blackhole.consume(node.getSubscribers()),
-                            () -> {
-                            });
+    public int missStringFind(TopicFinderState state) {
+        return state.find(state.missTopicSamples[state.nextIndex()]);
     }
 
     @Benchmark
-    public void wildcardSeparatedFind(TopicFinderState state, Blackhole blackhole) {
-        SeparatedCharSequence topic = state.wildcardSeqSamples[ThreadLocalRandom.current().nextInt(state.wildcardSeqSamples.length)];
-        state.root.findTopic(topic,
-                            node -> blackhole.consume(node.getSubscribers()),
-                            () -> {
-                            });
+    public int missSeparatedFind(TopicFinderState state) {
+        return state.find(state.missSeqSamples[state.nextIndex()]);
+    }
+
+    @Benchmark
+    public int wildcardStringFind(TopicFinderState state) {
+        return state.find(state.wildcardTopicSamples[state.nextIndex()]);
+    }
+
+    @Benchmark
+    public int wildcardSeparatedFind(TopicFinderState state) {
+        return state.find(state.wildcardSeqSamples[state.nextIndex()]);
     }
 }

--- a/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmark.java
+++ b/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmark.java
@@ -1,0 +1,108 @@
+package org.jetlinks.core.benchmark;
+
+import org.jetlinks.core.lang.SeparatedCharSequence;
+import org.jetlinks.core.lang.SharedPathString;
+import org.jetlinks.core.topic.Topic;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 针对 TopicFinder 的精确查找与 wildcard 查找微基准.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 3)
+@Measurement(iterations = 2, time = 5)
+@Fork(value = 0, jvmArgs = {"-Xms2g", "-Xmx2g", "-XX:+UseG1GC"})
+public class TopicFinderJmhBenchmark {
+
+    private static final int TENANT_COUNT = 256;
+    private static final int PRODUCT_COUNT = 128;
+    private static final String EXACT_SUFFIX = "/message/property/report";
+    private static final String WILDCARD_SUFFIX = "/message/*";
+
+    @State(Scope.Benchmark)
+    public static class TopicFinderState {
+        Topic<Integer> root = Topic.createRoot();
+        String[] exactTopicSamples = new String[1024];
+        SeparatedCharSequence[] exactSeqSamples = new SeparatedCharSequence[1024];
+        String[] wildcardTopicSamples = new String[1024];
+        SeparatedCharSequence[] wildcardSeqSamples = new SeparatedCharSequence[1024];
+
+        @Setup(Level.Trial)
+        public void init() {
+            for (int tenant = 0; tenant < TENANT_COUNT; tenant++) {
+                root.append("/tenant/" + tenant + "/device/**").subscribe(tenant);
+                for (int product = 0; product < PRODUCT_COUNT; product++) {
+                    root.append("/tenant/" + tenant + "/device/" + product + EXACT_SUFFIX)
+                        .subscribe(product);
+                    root.append("/tenant/" + tenant + "/device/*" + EXACT_SUFFIX)
+                        .subscribe(product);
+                    root.append("/tenant/" + tenant + "/device/" + product + WILDCARD_SUFFIX)
+                        .subscribe(product);
+                }
+            }
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            for (int i = 0; i < exactTopicSamples.length; i++) {
+                int tenant = random.nextInt(TENANT_COUNT);
+                int product = random.nextInt(PRODUCT_COUNT);
+                String exact = "/tenant/" + tenant + "/device/" + product + EXACT_SUFFIX;
+                String wildcard = "/tenant/" + tenant + "/device/" + product + "/message/*";
+                exactTopicSamples[i] = exact;
+                exactSeqSamples[i] = SharedPathString.of(exact);
+                wildcardTopicSamples[i] = wildcard;
+                wildcardSeqSamples[i] = SharedPathString.of(wildcard);
+            }
+        }
+    }
+
+    @Benchmark
+    public void exactStringFind(TopicFinderState state, Blackhole blackhole) {
+        String topic = state.exactTopicSamples[ThreadLocalRandom.current().nextInt(state.exactTopicSamples.length)];
+        state.root.findTopic(topic,
+                            node -> blackhole.consume(node.getSubscribers()),
+                            () -> {
+                            });
+    }
+
+    @Benchmark
+    public void exactSeparatedFind(TopicFinderState state, Blackhole blackhole) {
+        SeparatedCharSequence topic = state.exactSeqSamples[ThreadLocalRandom.current().nextInt(state.exactSeqSamples.length)];
+        state.root.findTopic(topic,
+                            node -> blackhole.consume(node.getSubscribers()),
+                            () -> {
+                            });
+    }
+
+    @Benchmark
+    public void wildcardStringFind(TopicFinderState state, Blackhole blackhole) {
+        String topic = state.wildcardTopicSamples[ThreadLocalRandom.current().nextInt(state.wildcardTopicSamples.length)];
+        state.root.findTopic(topic,
+                            node -> blackhole.consume(node.getSubscribers()),
+                            () -> {
+                            });
+    }
+
+    @Benchmark
+    public void wildcardSeparatedFind(TopicFinderState state, Blackhole blackhole) {
+        SeparatedCharSequence topic = state.wildcardSeqSamples[ThreadLocalRandom.current().nextInt(state.wildcardSeqSamples.length)];
+        state.root.findTopic(topic,
+                            node -> blackhole.consume(node.getSubscribers()),
+                            () -> {
+                            });
+    }
+}

--- a/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmarkTest.java
+++ b/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmarkTest.java
@@ -1,24 +1,48 @@
 package org.jetlinks.core.benchmark;
 
+import org.junit.Assume;
 import org.junit.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
+/**
+ * TopicFinder JMH 的显式运行入口，默认测试流程不会执行耗时基准。
+ */
 public class TopicFinderJmhBenchmarkTest {
 
     @Test
     public void shouldRunTopicFinderBenchmark() throws Exception {
-        Options opt = new OptionsBuilder()
-            .include(TopicFinderJmhBenchmark.class.getSimpleName())
-            .warmupIterations(1)
-            .warmupTime(TimeValue.seconds(1))
-            .measurementIterations(1)
-            .measurementTime(TimeValue.seconds(1))
-            .forks(0)
+        Assume.assumeTrue("enable with -Dtopic.finder.benchmark=true",
+                          Boolean.getBoolean("topic.finder.benchmark"));
+
+        int forks = Integer.getInteger("topic.finder.forks", 3);
+        int warmupIterations = Integer.getInteger("topic.finder.warmupIterations", 3);
+        int measurementIterations = Integer.getInteger("topic.finder.measurementIterations", 5);
+        int iterationSeconds = Integer.getInteger("topic.finder.iterationSeconds", 1);
+        String result = System.getProperty(
+            "topic.finder.result",
+            "target/topic-finder-benchmark.json");
+        String include = System.getProperty(
+            "topic.finder.include",
+            TopicFinderJmhBenchmark.class.getSimpleName());
+
+        Options options = new OptionsBuilder()
+            .include(include)
+            .threads(1)
+            .forks(forks)
+            .warmupIterations(warmupIterations)
+            .warmupTime(TimeValue.seconds(iterationSeconds))
+            .measurementIterations(measurementIterations)
+            .measurementTime(TimeValue.seconds(iterationSeconds))
+            .addProfiler(GCProfiler.class)
+            .result(result)
+            .resultFormat(ResultFormatType.JSON)
             .build();
 
-        new Runner(opt).run();
+        new Runner(options).run();
     }
 }

--- a/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmarkTest.java
+++ b/src/test/java/org/jetlinks/core/benchmark/TopicFinderJmhBenchmarkTest.java
@@ -1,0 +1,24 @@
+package org.jetlinks.core.benchmark;
+
+import org.junit.Test;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+public class TopicFinderJmhBenchmarkTest {
+
+    @Test
+    public void shouldRunTopicFinderBenchmark() throws Exception {
+        Options opt = new OptionsBuilder()
+            .include(TopicFinderJmhBenchmark.class.getSimpleName())
+            .warmupIterations(1)
+            .warmupTime(TimeValue.seconds(1))
+            .measurementIterations(1)
+            .measurementTime(TimeValue.seconds(1))
+            .forks(0)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/src/test/java/org/jetlinks/core/topic/TopicContractTest.java
+++ b/src/test/java/org/jetlinks/core/topic/TopicContractTest.java
@@ -1,0 +1,161 @@
+package org.jetlinks.core.topic;
+
+import org.jetlinks.core.lang.SharedPathString;
+import org.junit.Assert;
+import org.junit.Test;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class TopicContractTest {
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testSubscriberLifecycle() {
+        Topic<String> root = Topic.createRoot();
+        Topic<String> topic = root.append("/device/001");
+
+        Assert.assertFalse(root.subscribed("subscriber"));
+        Assert.assertTrue(root.getSubscribers().isEmpty());
+        root.unsubscribe(ignore -> true);
+        root.unsubscribeAll();
+
+        AtomicInteger supplierCalls = new AtomicInteger();
+        Assert.assertEquals("lazy", topic.getSubscriberOrSubscribe(() -> {
+            supplierCalls.incrementAndGet();
+            return "lazy";
+        }));
+        Assert.assertEquals("lazy", topic.getSubscriberOrSubscribe(() -> {
+            supplierCalls.incrementAndGet();
+            return "unused";
+        }));
+        Assert.assertEquals(1, supplierCalls.get());
+
+        topic.unsubscribeAll();
+        topic.subscribe("repeat");
+        topic.subscribe("repeat");
+        topic.subscribe("single");
+        Assert.assertEquals(List.of("single"), topic.unsubscribe("repeat", "single"));
+        Assert.assertTrue(topic.subscribed("repeat"));
+        Assert.assertTrue(topic.unsubscribe0("repeat"));
+        Assert.assertFalse(topic.subscribed("repeat"));
+
+        topic.subscribe0("replace", false);
+        topic.subscribe0("replace", true);
+        Assert.assertTrue(topic.unsubscribe0("replace", true));
+        Assert.assertFalse(topic.unsubscribe0("replace", true));
+
+        topic.subscribe("keep", "remove");
+        topic.unsubscribe("remove"::equals);
+        Assert.assertEquals(Set.of("keep"), topic.getSubscribers());
+        Assert.assertTrue(topic.unsubscribe0("missing"));
+        Assert.assertEquals(1, root.getTotalSubscriber());
+    }
+
+    @Test
+    public void testPathAndSeparatedSequenceContract() {
+        Topic<String> root = Topic.createRoot();
+        Assert.assertSame(root, root.append((String) null));
+        Assert.assertSame(root, root.append(""));
+        Assert.assertSame(root, root.append("/"));
+        Assert.assertSame(root, root.append((String[]) null));
+        Assert.assertSame(root, root.append(new String[0]));
+
+        Topic<String> topic = root.append(new String[]{"", "device", "001"});
+        Assert.assertEquals("/device/001", topic.getTopic());
+        Assert.assertArrayEquals(new String[]{"", "device", "001"}, topic.asStringArray());
+        Assert.assertEquals('/', topic.separator());
+        Assert.assertEquals(3, topic.size());
+        Assert.assertEquals("", topic.get(0));
+        Assert.assertEquals("device", topic.get(1));
+        Assert.assertEquals("001", topic.get(2));
+        Assert.assertEquals(9, topic.length());
+        Assert.assertSame(topic, topic.intern());
+        Assert.assertTrue(topic.toString().contains("/device/001"));
+
+        assertThrows(StringIndexOutOfBoundsException.class, () -> topic.get(3));
+        assertThrows(UnsupportedOperationException.class, () -> topic.replace(1, "new"));
+        assertThrows(UnsupportedOperationException.class, () -> topic.append('x'));
+        assertThrows(UnsupportedOperationException.class, () -> topic.append((CharSequence) "x"));
+        assertThrows(UnsupportedOperationException.class,
+                     () -> topic.append(new CharSequence[]{"x", "y"}));
+        assertThrows(UnsupportedOperationException.class,
+                     () -> topic.append((CharSequence) "xyz", 0, 1));
+        assertThrows(UnsupportedOperationException.class, () -> topic.range(0, 1));
+        assertThrows(UnsupportedOperationException.class, () -> topic.charAt(0));
+        assertThrows(UnsupportedOperationException.class, () -> topic.subSequence(0, 1));
+
+        Topic<String> equal = Topic.<String>createRoot().append("/device/001");
+        Topic<String> sibling = Topic.<String>createRoot().append("/device/002");
+        Topic<String> shallower = Topic.<String>createRoot().append("/device");
+        Assert.assertEquals(0, topic.compareTo(topic));
+        Assert.assertEquals(0, topic.compareTo(equal));
+        Assert.assertNotEquals(0, topic.compareTo(sibling));
+        Assert.assertTrue(topic.compareTo(shallower) < 0);
+        Assert.assertEquals(0, topic.compareTo(SharedPathString.of("/device/001")));
+        Assert.assertEquals(topic, equal);
+        Assert.assertNotEquals(topic, sibling);
+        Assert.assertNotEquals(topic, "device/001");
+        Assert.assertEquals(topic.hashCode(), equal.hashCode());
+    }
+
+    @Test
+    public void testTraversalViewAndCleanupCallback() {
+        Topic<String> root = Topic.createRoot();
+        root.append("/device/001").subscribe("device-1");
+        root.append("/device/002");
+        root.append("/gateway/001").subscribe("gateway-1");
+
+        Assert.assertEquals(5, root.getTotalTopic());
+        Assert.assertEquals(2, root.getTotalSubscriber());
+
+        Set<String> traversed = root
+            .getAllSubscriber()
+            .map(Topic::getTopic)
+            .collect(Collectors.toSet())
+            .block();
+        Assert.assertNotNull(traversed);
+        Assert.assertEquals(5, traversed.size());
+        Assert.assertTrue(traversed.contains("/device/001"));
+        StepVerifier
+            .create(root.getAllSubscriber().take(1))
+            .expectNextCount(1)
+            .verifyComplete();
+
+        TopicView view = root.view();
+        Assert.assertEquals("", view.getPart());
+        Assert.assertNotNull(view.getChildren());
+        Assert.assertEquals(2, view.getChildren().size());
+        TopicView deviceView = view
+            .getChildren()
+            .stream()
+            .filter(child -> "device".equals(child.getPart()))
+            .findFirst()
+            .orElseThrow();
+        Assert.assertNotNull(deviceView.getChildren());
+
+        List<Boolean> cleanupStates = new ArrayList<>();
+        Assert.assertFalse(root.cleanup((cleaned, topic) -> cleanupStates.add(cleaned)));
+        Assert.assertTrue(cleanupStates.contains(Boolean.TRUE));
+        Assert.assertTrue(cleanupStates.contains(Boolean.FALSE));
+        Assert.assertTrue(root.getTopic("/device/002").isEmpty());
+
+        root.clean();
+        Assert.assertEquals(0, root.getTotalTopic());
+        Assert.assertEquals(0, root.getTotalSubscriber());
+        Assert.assertTrue(root.getChildren().isEmpty());
+    }
+
+    private static void assertThrows(Class<? extends Throwable> type, Runnable action) {
+        try {
+            action.run();
+            Assert.fail("expected " + type.getSimpleName());
+        } catch (Throwable error) {
+            Assert.assertTrue("unexpected " + error, type.isInstance(error));
+        }
+    }
+}

--- a/src/test/java/org/jetlinks/core/topic/TopicContractTest.java
+++ b/src/test/java/org/jetlinks/core/topic/TopicContractTest.java
@@ -150,6 +150,19 @@ public class TopicContractTest {
         Assert.assertTrue(root.getChildren().isEmpty());
     }
 
+    @Test
+    public void testLookupMissDoesNotCreateChildrenMap() {
+        Topic<String> root = Topic.createRoot();
+        Assert.assertNull(root.getChildrenMap());
+        Assert.assertTrue(root.getTopic("/missing/device").isEmpty());
+        Assert.assertNull(root.getChildrenMap());
+
+        Topic<String> device = root.append("/device");
+        Assert.assertNull(device.getChildrenMap());
+        Assert.assertTrue(root.getTopic("/device/missing").isEmpty());
+        Assert.assertNull(device.getChildrenMap());
+    }
+
     private static void assertThrows(Class<? extends Throwable> type, Runnable action) {
         try {
             action.run();

--- a/src/test/java/org/jetlinks/core/topic/TopicFinderOverloadTest.java
+++ b/src/test/java/org/jetlinks/core/topic/TopicFinderOverloadTest.java
@@ -29,16 +29,34 @@ public class TopicFinderOverloadTest {
 
     @Test
     public void testCharSequenceOverloads() {
-        SeparatedCharSequence separated =
-            SharedPathString.of("/device/001/message/property/report");
-        CharSequence plain = new StringBuilder("/device/001/message/property/report");
+        for (String path : List.of("/device/001/message/property/report",
+                                   "device/001/message/property/report")) {
+            SeparatedCharSequence separated = SharedPathString.of(path);
+            CharSequence plain = new StringBuilder(path);
 
-        assertTwoArgumentOverload(separated);
-        assertTwoArgumentOverload(plain);
-        assertOneArgumentOverload(separated);
-        assertOneArgumentOverload(plain);
-        assertFourArgumentOverload(separated);
-        assertFourArgumentOverload(plain);
+            assertZeroArgumentOverload(separated);
+            assertZeroArgumentOverload(plain);
+            assertTwoArgumentOverload(separated);
+            assertTwoArgumentOverload(plain);
+            assertOneArgumentOverload(separated);
+            assertOneArgumentOverload(plain);
+            assertFourArgumentOverload(separated);
+            assertFourArgumentOverload(plain);
+        }
+    }
+
+    @Test
+    public void testArrayOverloadWithAndWithoutLeadingSeparator() {
+        for (String[] parts : List.of(
+            new String[]{"", "device", "001", "message", "property", "report"},
+            new String[]{"device", "001", "message", "property", "report"})) {
+            List<Topic<String>> matched = new ArrayList<>();
+            TopicFinder.find(root, parts, null, null, null, null,
+                             (a, b, c, d, found) -> matched.add(found),
+                             (a, b, c, d) -> {
+                             });
+            Assert.assertTrue(paths(matched).contains("/device/001/message/property/report"));
+        }
     }
 
     @Test
@@ -154,6 +172,14 @@ public class TopicFinderOverloadTest {
                              matched.add(found);
                          },
                          (a, b) -> ended.incrementAndGet());
+        Assert.assertEquals(1, ended.get());
+        Assert.assertTrue(paths(matched).contains("/device/001/message/property/report"));
+    }
+
+    private void assertZeroArgumentOverload(CharSequence topic) {
+        List<Topic<String>> matched = new ArrayList<>();
+        AtomicInteger ended = new AtomicInteger();
+        TopicFinder.find(root, topic, matched::add, ended::incrementAndGet);
         Assert.assertEquals(1, ended.get());
         Assert.assertTrue(paths(matched).contains("/device/001/message/property/report"));
     }

--- a/src/test/java/org/jetlinks/core/topic/TopicFinderOverloadTest.java
+++ b/src/test/java/org/jetlinks/core/topic/TopicFinderOverloadTest.java
@@ -1,0 +1,198 @@
+package org.jetlinks.core.topic;
+
+import org.jetlinks.core.lang.SeparatedCharSequence;
+import org.jetlinks.core.lang.SharedPathString;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class TopicFinderOverloadTest {
+
+    private Topic<String> root;
+
+    @Before
+    public void init() {
+        root = Topic.createRoot();
+        root.append("/device/001/message/property/report").subscribe("exact");
+        root.append("/device/002/message/property/report").subscribe("exact-2");
+        root.append("/device/*/message/property/report").subscribe("star");
+        root.append("/device/**").subscribe("double-star");
+        root.append("/device/**/event/*").subscribe("event");
+    }
+
+    @Test
+    public void testCharSequenceOverloads() {
+        SeparatedCharSequence separated =
+            SharedPathString.of("/device/001/message/property/report");
+        CharSequence plain = new StringBuilder("/device/001/message/property/report");
+
+        assertTwoArgumentOverload(separated);
+        assertTwoArgumentOverload(plain);
+        assertOneArgumentOverload(separated);
+        assertOneArgumentOverload(plain);
+        assertFourArgumentOverload(separated);
+        assertFourArgumentOverload(plain);
+    }
+
+    @Test
+    public void testSeparatedWildcardSearchMatrix() {
+        assertPaths(SharedPathString.of("/device/*/message/property/report"),
+                    "/device/001/message/property/report",
+                    "/device/002/message/property/report",
+                    "/device/*/message/property/report",
+                    "/device/**");
+        assertPaths(SharedPathString.of("/device/**"),
+                    "/device",
+                    "/device/001",
+                    "/device/002",
+                    "/device/*",
+                    "/device/**",
+                    "/device/001/message",
+                    "/device/002/message",
+                    "/device/*/message",
+                    "/device/001/message/property",
+                    "/device/002/message/property",
+                    "/device/*/message/property",
+                    "/device/001/message/property/report",
+                    "/device/002/message/property/report",
+                    "/device/*/message/property/report",
+                    "/device/**/event",
+                    "/device/**/event/*");
+        assertPaths(SharedPathString.of("/device/001/message/event/alarm"),
+                    "/device/**",
+                    "/device/**/event/*");
+    }
+
+    @Test
+    public void testNonStringSeparatedPartAndStaticTopicWrappers() {
+        SeparatedCharSequence topic = SharedPathString
+            .of("/device/001/message/property/report")
+            .replace(2, new StringBuilder("001"));
+
+        List<Topic<String>> matched = new ArrayList<>();
+        AtomicInteger ended = new AtomicInteger();
+        Topic.find(topic, root, "a", "b", "c", "d",
+                   (a, b, c, d, found) -> matched.add(found),
+                   (a, b, c, d) -> ended.incrementAndGet());
+        Assert.assertEquals(1, ended.get());
+        Assert.assertTrue(paths(matched).contains("/device/001/message/property/report"));
+
+        matched.clear();
+        Topic.find("/device/001/message/property/report", root, "a", "b", "c", "d",
+                   (a, b, c, d, found) -> matched.add(found),
+                   (a, b, c, d) -> ended.incrementAndGet());
+        Assert.assertEquals(2, ended.get());
+        Assert.assertTrue(paths(matched).contains("/device/001/message/property/report"));
+    }
+
+    @Test
+    public void testTopicInstanceFindOverloads() {
+        String path = "/device/001/message/property/report";
+        Set<String> expected = Set.of(path,
+                                      "/device/*/message/property/report",
+                                      "/device/**");
+        AtomicInteger ended = new AtomicInteger();
+        List<Topic<String>> matched = new ArrayList<>();
+
+        root.findTopic((CharSequence) new StringBuilder(path), "a",
+                       (a, found) -> {
+                           Assert.assertEquals("a", a);
+                           matched.add(found);
+                       },
+                       a -> ended.incrementAndGet());
+        Assert.assertEquals(expected, paths(matched));
+
+        matched.clear();
+        root.findTopic(SharedPathString.of(path), "a", "b",
+                       (a, b, found) -> {
+                           Assert.assertEquals("a", a);
+                           Assert.assertEquals("b", b);
+                           matched.add(found);
+                       },
+                       (a, b) -> ended.incrementAndGet());
+        Assert.assertEquals(expected, paths(matched));
+
+        matched.clear();
+        root.findTopic(SharedPathString.of(path), "a", "b", "c", "d",
+                       (a, b, c, d, found) -> matched.add(found),
+                       (a, b, c, d) -> ended.incrementAndGet());
+        Assert.assertEquals(expected, paths(matched));
+
+        matched.clear();
+        root.findTopic(path, "a", "b", "c", "d",
+                       (a, b, c, d, found) -> matched.add(found),
+                       (a, b, c, d) -> ended.incrementAndGet());
+        Assert.assertEquals(expected, paths(matched));
+        Assert.assertEquals(4, ended.get());
+    }
+
+    @Test
+    public void testEmptyGenericStringOverload() {
+        List<Topic<String>> matched = new ArrayList<>();
+        AtomicInteger ended = new AtomicInteger();
+        TopicFinder.find(root, "", "a", "b", "c", "d",
+                         (a, b, c, d, topic) -> matched.add(topic),
+                         (a, b, c, d) -> ended.incrementAndGet());
+        Assert.assertEquals(List.of(root), matched);
+        Assert.assertEquals(1, ended.get());
+    }
+
+    private void assertTwoArgumentOverload(CharSequence topic) {
+        List<Topic<String>> matched = new ArrayList<>();
+        AtomicInteger ended = new AtomicInteger();
+        TopicFinder.find(root, topic, "a", "b",
+                         (a, b, found) -> {
+                             Assert.assertEquals("a", a);
+                             Assert.assertEquals("b", b);
+                             matched.add(found);
+                         },
+                         (a, b) -> ended.incrementAndGet());
+        Assert.assertEquals(1, ended.get());
+        Assert.assertTrue(paths(matched).contains("/device/001/message/property/report"));
+    }
+
+    private void assertOneArgumentOverload(CharSequence topic) {
+        List<Topic<String>> matched = new ArrayList<>();
+        AtomicInteger ended = new AtomicInteger();
+        TopicFinder.find(root, topic, "context",
+                         (context, found) -> {
+                             Assert.assertEquals("context", context);
+                             matched.add(found);
+                         },
+                         context -> ended.incrementAndGet());
+        Assert.assertEquals(1, ended.get());
+        Assert.assertTrue(paths(matched).contains("/device/001/message/property/report"));
+    }
+
+    private void assertFourArgumentOverload(CharSequence topic) {
+        List<Topic<String>> matched = new ArrayList<>();
+        AtomicInteger ended = new AtomicInteger();
+        TopicFinder.find(root, topic, "a", "b", "c", "d",
+                         (a, b, c, d, found) -> matched.add(found),
+                         (a, b, c, d) -> ended.incrementAndGet());
+        Assert.assertEquals(1, ended.get());
+        Assert.assertTrue(paths(matched).contains("/device/001/message/property/report"));
+    }
+
+    private void assertPaths(SeparatedCharSequence topic, String... expected) {
+        List<Topic<String>> matched = new ArrayList<>();
+        TopicFinder.find(root, topic, matched::add, () -> {
+        });
+        Assert.assertEquals(Set.of(expected), paths(matched));
+        Assert.assertEquals(matched.size(), new HashSet<>(matched).size());
+    }
+
+    private static Set<String> paths(List<Topic<String>> topics) {
+        return topics
+            .stream()
+            .map(Topic::getTopic)
+            .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/org/jetlinks/core/topic/TopicFinderTest.java
+++ b/src/test/java/org/jetlinks/core/topic/TopicFinderTest.java
@@ -195,6 +195,16 @@ public class TopicFinderTest {
     }
 
     @Test
+    public void testExactSearchShouldStillTraverseWildcardSubscribers() {
+        root.append("device").append("001").subscribe("exact");
+        root.append("device").append("*").subscribe("star");
+        root.append("device").append("**").subscribe("dstar");
+
+        Set<String> matched = matchedPaths(root, "device/001");
+        Assert.assertEquals(Set.of("/device/001", "/device/*", "/device/**"), matched);
+    }
+
+    @Test
     public void testMixedStarAndDoubleStarInTree() {
         root.append("a").append("*").append("c").subscribe("s1");
         root.append("a").append("**").subscribe("s2");

--- a/src/test/java/org/jetlinks/core/topic/TopicFinderTest.java
+++ b/src/test/java/org/jetlinks/core/topic/TopicFinderTest.java
@@ -297,6 +297,25 @@ public class TopicFinderTest {
     }
 
     @Test
+    public void testLargeDeduplicationSetDoesNotRemainRetained() {
+        TopicFinder.ReusableTopicSet reusable = new TopicFinder.ReusableTopicSet();
+        Set<Topic<String>> large = reusable.values();
+        for (int i = 0; i < 5_000; i++) {
+            large.add(Topic.createRoot());
+        }
+
+        reusable.reset();
+        Set<Topic<String>> compact = reusable.values();
+        Assert.assertNotSame(large, compact);
+        Assert.assertTrue(compact.isEmpty());
+
+        compact.add(root);
+        reusable.reset();
+        Assert.assertSame(compact, reusable.<String>values());
+        Assert.assertTrue(compact.isEmpty());
+    }
+
+    @Test
     public void testMixedStarAndDoubleStarInTree() {
         root.append("a").append("*").append("c").subscribe("s1");
         root.append("a").append("**").subscribe("s2");

--- a/src/test/java/org/jetlinks/core/topic/TopicFinderTest.java
+++ b/src/test/java/org/jetlinks/core/topic/TopicFinderTest.java
@@ -3,6 +3,7 @@ package org.jetlinks.core.topic;
 import lombok.extern.slf4j.Slf4j;
 import org.jetlinks.core.lang.SeparatedCharSequence;
 import org.jetlinks.core.lang.SharedPathString;
+import org.jetlinks.core.utils.TopicUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,6 +28,13 @@ public class TopicFinderTest {
         return list;
     }
 
+    private static List<Topic<String>> collectMatched(Topic<String> root, SeparatedCharSequence searchTopic) {
+        List<Topic<String>> list = new ArrayList<>();
+        TopicFinder.find(root, searchTopic, list::add, () -> {
+        });
+        return list;
+    }
+
     /**
      * 返回匹配到的 topic 路径字符串集合，便于断言.
      */
@@ -34,6 +42,17 @@ public class TopicFinderTest {
         return collectMatched(root, searchTopic).stream()
                                                 .map(Topic::getTopic)
                                                 .collect(Collectors.toSet());
+    }
+
+    private static Set<String> matchedSubscriberPaths(Topic<String> root, CharSequence searchTopic) {
+        List<Topic<String>> matched = searchTopic instanceof SeparatedCharSequence
+            ? collectMatched(root, (SeparatedCharSequence) searchTopic)
+            : collectMatched(root, searchTopic.toString());
+        return matched
+            .stream()
+            .filter(topic -> !topic.getSubscribers().isEmpty())
+            .map(Topic::getTopic)
+            .collect(Collectors.toSet());
     }
 
     @Before
@@ -202,6 +221,79 @@ public class TopicFinderTest {
 
         Set<String> matched = matchedPaths(root, "device/001");
         Assert.assertEquals(Set.of("/device/001", "/device/*", "/device/**"), matched);
+    }
+
+    @Test
+    public void testExactSearchReferenceMatrix() {
+        List<String> patterns = List.of(
+            "/tenant/alpha/device/001/message/property/report",
+            "/tenant/*/device/*/message/property/report",
+            "/tenant/**",
+            "/**/message/property/report",
+            "/tenant/alpha/device/**",
+            "/tenant/alpha/**/property/*"
+        );
+        List<String> topics = List.of(
+            "/tenant/alpha/device/001/message/property/report",
+            "/tenant/beta/device/002/message/property/report",
+            "/tenant/alpha/device/001/message/event/alarm",
+            "/tenant/alpha/gateway/001/online",
+            "/other/alpha/device/001/message/property/report"
+        );
+        patterns.forEach(pattern -> root.append(pattern).subscribe(pattern));
+
+        for (String topic : topics) {
+            Set<String> expected = patterns
+                .stream()
+                .filter(pattern -> TopicUtils.match(pattern, topic))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            Assert.assertEquals(topic, expected, matchedSubscriberPaths(root, topic));
+            Assert.assertEquals(topic,
+                                expected,
+                                matchedSubscriberPaths(root, SharedPathString.of(topic)));
+        }
+    }
+
+    @Test
+    public void testWildcardCacheLifecycle() {
+        Topic<String> exact = root.append("/device/001");
+        Topic<String> star = root.append("/device/*");
+        Topic<String> doubleStar = root.append("/device/**");
+        exact.subscribe("exact");
+        star.subscribe("star");
+        doubleStar.subscribe("double-star");
+
+        Assert.assertEquals(Set.of("/device/001", "/device/*", "/device/**"),
+                            matchedPaths(root, "/device/001"));
+
+        star.unsubscribe("star");
+        doubleStar.unsubscribe("double-star");
+        root.cleanup();
+
+        Assert.assertEquals(Set.of("/device/001"), matchedPaths(root, "/device/001"));
+        Assert.assertTrue(root.getTopic("/device/*").isEmpty());
+        Assert.assertTrue(root.getTopic("/device/**").isEmpty());
+
+        root.append("/device/*").subscribe("star-recreated");
+        root.append("/device/**").subscribe("double-star-recreated");
+        Assert.assertEquals(Set.of("/device/001", "/device/*", "/device/**"),
+                            matchedPaths(root, "/device/001"));
+
+        root.clean();
+        Assert.assertEquals(0, root.getTotalTopic());
+        root.append("/device/**").subscribe("double-star-after-clean");
+        Assert.assertEquals(Set.of("/device/**"), matchedPaths(root, "/device/001"));
+    }
+
+    @Test
+    public void testExactSearchDoesNotEmitSameNodeTwice() {
+        root.append("/device/001/message/property/report").subscribe("exact");
+        root.append("/device/*/message/property/report").subscribe("star");
+        root.append("/device/**").subscribe("double-star");
+
+        List<Topic<String>> matched = collectMatched(root, "/device/001/message/property/report");
+        Assert.assertEquals(new HashSet<>(matched).size(), matched.size());
     }
 
     @Test

--- a/src/test/java/org/jetlinks/core/topic/TopicLifecycleConcurrencyTest.java
+++ b/src/test/java/org/jetlinks/core/topic/TopicLifecycleConcurrencyTest.java
@@ -1,0 +1,145 @@
+package org.jetlinks.core.topic;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+public class TopicLifecycleConcurrencyTest {
+
+    @Test
+    public void testSubscribeAndAppendFromNodeRemovedByCleanup() {
+        Topic<String> root = Topic.createRoot();
+        Topic<String> staleLeaf = root.append("/device/001");
+        Topic<String> staleBranch = root.append("/gateway");
+
+        root.cleanup();
+        Assert.assertEquals(0, root.getTotalTopic());
+
+        staleLeaf.subscribe("late-device");
+        staleBranch.append("001").subscribe("late-gateway");
+
+        Assert.assertEquals(Set.of("late-device"), matchedSubscribers(root, "/device/001"));
+        Assert.assertEquals(Set.of("late-gateway"), matchedSubscribers(root, "/gateway/001"));
+        Assert.assertTrue(staleLeaf.unsubscribe("late-device").contains("late-device"));
+        Assert.assertTrue(matchedSubscribers(root, "/device/001").isEmpty());
+        assertWildcardIndex(root);
+    }
+
+    @Test
+    public void testSubscribeFromDescendantRemovedByClean() {
+        Topic<String> root = Topic.createRoot();
+        Topic<String> staleLeaf = root.append("/org/001/device/001/message/property/report");
+        staleLeaf.subscribe("before-clean");
+
+        root.clean();
+        staleLeaf.subscribe("after-clean");
+
+        Assert.assertEquals(Set.of("after-clean"),
+                            matchedSubscribers(root,
+                                               "/org/001/device/001/message/property/report"));
+        assertWildcardIndex(root);
+    }
+
+    @Test(timeout = 20_000)
+    public void testConcurrentMutationCleanupAndClean() throws Exception {
+        Topic<String> root = Topic.createRoot();
+        int writerCount = 4;
+        int iterations = 3_000;
+        ExecutorService executor = Executors.newFixedThreadPool(writerCount + 1);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+        List<Future<?>> writers = new ArrayList<>();
+
+        Future<?> cleaner = executor.submit(() -> {
+            await(start);
+            int rounds = 0;
+            while (running.get()) {
+                if ((++rounds & 31) == 0) {
+                    root.clean();
+                } else {
+                    root.cleanup();
+                }
+            }
+        });
+
+        for (int writer = 0; writer < writerCount; writer++) {
+            int writerId = writer;
+            writers.add(executor.submit(() -> {
+                await(start);
+                for (int i = 0; i < iterations; i++) {
+                    String subscriber = writerId + "-" + i;
+                    String prefix = "/org/" + (i & 31) + "/device/" + writerId;
+                    Topic<String> exact = root.append(prefix + "/message/property/report");
+                    Topic<String> wildcard = root.append(prefix + "/message/**");
+                    exact.subscribe(subscriber);
+                    wildcard.subscribe(subscriber);
+                    exact.unsubscribe(subscriber);
+                    wildcard.unsubscribe(subscriber);
+                }
+            }));
+        }
+
+        start.countDown();
+        try {
+            for (Future<?> writer : writers) {
+                writer.get(15, TimeUnit.SECONDS);
+            }
+        } finally {
+            running.set(false);
+        }
+        cleaner.get(5, TimeUnit.SECONDS);
+        executor.shutdownNow();
+
+        root.clean();
+        root.append("/org/001/device/001/message/property/report").subscribe("exact");
+        root.append("/org/*/device/*/message/property/report").subscribe("star");
+        root.append("/org/**").subscribe("double-star");
+
+        Assert.assertEquals(Set.of("exact", "star", "double-star"),
+                            matchedSubscribers(root,
+                                               "/org/001/device/001/message/property/report"));
+        assertWildcardIndex(root);
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException error) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(error);
+        }
+    }
+
+    private static Set<String> matchedSubscribers(Topic<String> root, String topic) {
+        return root
+            .findTopic(topic)
+            .flatMapIterable(Topic::getSubscribers)
+            .collect(Collectors.toSet())
+            .block();
+    }
+
+    private static void assertWildcardIndex(Topic<?> node) {
+        Map<String, ? extends Topic<?>> children = node.getChildrenMap();
+        Assert.assertSame(children == null ? null : children.get("*"),
+                          node.getStarChild());
+        Assert.assertSame(children == null ? null : children.get("**"),
+                          node.getDoubleStarChild());
+        if (children != null) {
+            for (Topic<?> child : children.values()) {
+                Assert.assertSame(node, child.getParent());
+                assertWildcardIndex(child);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 目的

- 基于最新 `1.3` 优化精确 Topic 发布热路径，并修复 append/subscribe 与 cleanup/clean 并发时的生命周期竞争。
- 保持 exact、`*`、`**` 及各 Topic 输入重载语义兼容，同时降低常驻内存和大 wildcard 查询后的内存滞留。

## 核心变动

- 模块 / 文件：优化 `Topic`、`TopicFinder`，补充重载、生命周期并发、JMH 与 JOL 验证。
- 行为变化：lookup miss 不再创建 Map；String、CharSequence、Separated 与数组支持有无前导 `/`；旧节点引用在被清理后继续 append/subscribe 会重建到当前树。
- 边界或约束变化：节点容器和 wildcard 索引在节点锁内更新；大 `**` 去重集合超过 4096 项后释放内部大表。
- 阶段提交：`524ce84c`、`5aa30825`、`56f53527`、`cabd4bc2`、`3609b19b`、`6d2965f0`。

## 设计与测试目标

- 任务契约：`docs/plans/topic-finder-performance.md`
- 权威文档：已原位同步最终实现、JMH/JOL、测试与风险。
- 用户确认：已确认执行。
- 测试目标：覆盖 exact/`*`/`**`、真实 device topic 形状、全部重载、无前导 `/`、lookup-only、cleanup/clean/reappend、并发竞争、旧引用重建、去重集合缩容和路由回归。
- 注释 / 公共契约：未新增 SPI/公共 API；并发生命周期与 detached 标记已补原因注释。
- 数据权限：不适用。
- 数据库兼容与性能：不适用。
- 链路追踪：不适用；同步进程内查找，无外部 I/O 或响应式上下文切换。
- MBean 运维可观测性：不适用；未新增后台任务、队列或管理器。
- 系统性求解：修复 volatile 容器二次读取、wildcard TOCTOU 和清理后悬空订阅；JMH 否决了回退超过 5% 的单字段 wildcard holder，并保留吞吐更高的 Separated 捕获适配器。

## 测试结果

- 测试命令：`mvn -q test`；Topic 定向测试；JMH 3 forks、3×1s warmup、5×1s measurement、GCProfiler；JOL ClassLayout/GraphLayout。
- 证据来源与复用判断：全量测试、JaCoCo 和最终 Separated 适配器 JMH 对应提交 `6d2965f0` 的等价 Git tree；JOL 对应最终 Topic 字段布局。
- 新增/更新测试：`TopicLifecycleConcurrencyTest`、`TopicFinderTest`、`TopicFinderOverloadTest`、`TopicContractTest`、`TopicFinderJmhBenchmark`。
- 单元测试：667 项，0 failure、0 error、2 skipped。
- 集成测试结果或不适用原因：不适用；不涉及数据库、中间件、集群 wire 协议或启动装配。
- 压力测试结果或不适用原因：相对最新 `1.3`，exact Separated 时延下降 12.37%～18.26%，miss Separated 下降 22.31%～29.69%，wildcard Separated 下降 4.32%～6.13%。实际 Separated 适配器约 16 B/op；0 B 方案造成 14.5%～18% 回退，未采用。
- 覆盖率：`TopicFinder` 行 255/269（94.8%）、分支 165/196（84.2%）；`Topic` 行 373/404（92.3%）、分支 224/272（82.4%）。

## 文档同步情况

- 已同步：`docs/plans/topic-finder-performance.md`。
- 未同步：无。
- 说明：JMH/JOL/JaCoCo 原始产物保留在本地 `target/`，不提交。

## 风险与说明

- 影响范围：`jetlinks-core` Topic 树查找、订阅生命周期和节点布局。
- 兼容性与发布边界：公开 API 未变；匹配、订阅计数、cleanup、序列化和路由语义保持兼容。
- 注释 / 公共契约：未新增 SPI；复杂并发边界已注释。
- 数据库兼容与 SQL 性能：不涉及。
- 链路追踪 / 可观测性：不涉及。
- MBean / 运维可观测性：不涉及。
- 未覆盖场景：未做跨 JVM/跨 CPU JIT 对比。
- 已知限制：直接修改 `getChildrenMap()` 返回 Map 仍不是受支持的树更新方式；Separated 实际重载为吞吐保留约 16 B/op。
- 回滚方式：回滚本 PR 提交可恢复最新 `1.3` 通用 DFS 与原生命周期实现。
