### PR TITLE
feat(device): 增加设备模块Thing契约

### DIFF
--- a/src/main/java/org/jetlinks/core/defaults/DefaultDeviceOperator.java
+++ b/src/main/java/org/jetlinks/core/defaults/DefaultDeviceOperator.java
@@ -92,6 +92,8 @@ public class DefaultDeviceOperator implements DeviceOperator, StorageConfigurabl
     @Setter
     private ThingRpcSupportChain rpcChain;
 
+    @Setter
+    private DeviceModuleThingProvider moduleThingProvider;
 
     public DefaultDeviceOperator(String id,
                                  ProtocolSupports supports,
@@ -198,6 +200,22 @@ public class DefaultDeviceOperator implements DeviceOperator, StorageConfigurabl
     @Override
     public String getDeviceId() {
         return id;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public Mono<org.jetlinks.core.things.Thing> getModuleThing(String moduleCode) {
+        DeviceModuleThingProvider provider = moduleThingProvider;
+        if (provider == null) {
+            return DeviceOperator.super.getModuleThing(moduleCode);
+        }
+        return provider
+            .getModuleThing(this, moduleCode)
+            .switchIfEmpty(DeviceOperator.super.getModuleThing(moduleCode));
     }
 
     @Override

--- a/src/main/java/org/jetlinks/core/device/DeviceModuleThingProvider.java
+++ b/src/main/java/org/jetlinks/core/device/DeviceModuleThingProvider.java
@@ -1,0 +1,24 @@
+package org.jetlinks.core.device;
+
+import org.jetlinks.core.things.Thing;
+import reactor.core.publisher.Mono;
+
+/**
+ * 设备模块物提供器,用于为支持模块能力的设备运行时按模块编码创建模块 {@link Thing}.
+ *
+ * @author zhouhao
+ * @since 2.3.0
+ */
+@FunctionalInterface
+public interface DeviceModuleThingProvider {
+
+    /**
+     * 获取设备下指定模块对应的物操作对象.
+     *
+     * @param device     父设备操作对象
+     * @param moduleCode 模块编码
+     * @return 模块物操作对象; 如果当前 provider 不支持此模块,可返回 {@link Mono#empty()}
+     */
+    Mono<Thing> getModuleThing(DeviceOperator device, String moduleCode);
+
+}

--- a/src/main/java/org/jetlinks/core/device/DeviceOperator.java
+++ b/src/main/java/org/jetlinks/core/device/DeviceOperator.java
@@ -39,6 +39,21 @@ public interface DeviceOperator extends Thing {
     String getDeviceId();
 
     /**
+     * 获取设备下指定模块对应的物操作对象.
+     * <p>
+     * 模块是设备内部的逻辑单元,不代表独立子设备。默认实现返回不支持,由具备模块能力的设备运行时覆盖。
+     *
+     * @param moduleCode 模块编码
+     * @return 模块物操作对象
+     * @see org.jetlinks.core.message.module.ThingModuleMessage
+     * @see org.jetlinks.core.message.module.DeviceModuleMessage
+     * @since 2.3.0
+     */
+    default Mono<Thing> getModuleThing(String moduleCode) {
+        return Mono.error(new UnsupportedOperationException("unsupported device module"));
+    }
+
+    /**
      * @return 当前设备连接所在服务器ID，如果设备未上线 {@link DeviceState#online}，则返回<code>null</code>
      */
     Mono<String> getConnectionServerId();

--- a/src/main/java/org/jetlinks/core/things/ThingMetadata.java
+++ b/src/main/java/org/jetlinks/core/things/ThingMetadata.java
@@ -116,6 +116,7 @@ public interface ThingMetadata extends Metadata, Jsonable {
         json.put("functions", getFunctions().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("events", getEvents().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("tags", getTags().stream().map(Jsonable::toJson).collect(Collectors.toList()));
+        json.put("modules", getModules().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("expands", getExpands());
         return json;
     }

--- a/src/test/java/org/jetlinks/core/defaults/DefaultDeviceOperatorTest.java
+++ b/src/test/java/org/jetlinks/core/defaults/DefaultDeviceOperatorTest.java
@@ -7,10 +7,12 @@ import org.jetlinks.core.message.*;
 import org.jetlinks.core.message.function.FunctionInvokeMessageReply;
 import org.jetlinks.core.message.interceptor.DeviceMessageSenderInterceptor;
 import org.jetlinks.core.message.property.ReadPropertyMessageReply;
+import org.jetlinks.core.things.Thing;
 import org.jetlinks.core.utils.IdUtils;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
@@ -38,6 +40,121 @@ public class DefaultDeviceOperatorTest {
                     }
                 }
         );
+    }
+
+    @Test
+    public void testGetModuleThingDefaultUnsupported() {
+        registry.register(DeviceInfo.builder()
+                                    .id("test-module-default")
+                                    .build())
+                .flatMap(device -> device.getModuleThing("module-a"))
+                .as(StepVerifier::create)
+                .expectError(UnsupportedOperationException.class)
+                .verify();
+    }
+
+    @Test
+    public void testGetModuleThingFromProvider() {
+        registry.register(DeviceInfo.builder()
+                                    .id("test-module-provider")
+                                    .build())
+                .cast(DefaultDeviceOperator.class)
+                .doOnNext(device -> device.setModuleThingProvider((parent, moduleCode) -> Mono.just(new Thing() {
+                    @Override
+                    public String getId() {
+                        return parent.getDeviceId() + ":" + moduleCode;
+                    }
+
+                    @Override
+                    public org.jetlinks.core.things.ThingType getType() {
+                        return org.jetlinks.core.things.ThingType.of("device-module");
+                    }
+
+                    @Override
+                    public Mono<? extends org.jetlinks.core.things.ThingTemplate> getTemplate() {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<Void> resetMetadata() {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<? extends org.jetlinks.core.things.ThingMetadata> getMetadata() {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<Boolean> updateMetadata(String metadata) {
+                        return Mono.just(false);
+                    }
+
+                    @Override
+                    public Mono<Boolean> updateMetadata(org.jetlinks.core.things.ThingMetadata metadata) {
+                        return Mono.just(false);
+                    }
+
+                    @Override
+                    public Mono<Value> getSelfConfig(String key) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<Value> getConfig(String key) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<org.jetlinks.core.Values> getSelfConfigs(java.util.Collection<String> keys) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<org.jetlinks.core.Values> getConfigs(java.util.Collection<String> keys) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<Boolean> setConfig(String key, Object value) {
+                        return Mono.just(false);
+                    }
+
+                    @Override
+                    public Mono<Boolean> setConfigs(java.util.Map<String, Object> conf) {
+                        return Mono.just(false);
+                    }
+
+                    @Override
+                    public Mono<Boolean> removeConfig(String key) {
+                        return Mono.just(false);
+                    }
+
+                    @Override
+                    public Mono<Value> getAndRemoveConfig(String key) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<Boolean> removeConfigs(java.util.Collection<String> key) {
+                        return Mono.just(false);
+                    }
+
+                    @Override
+                    public Mono<Void> refreshConfig(java.util.Collection<String> keys) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<Void> refreshAllConfig() {
+                        return Mono.empty();
+                    }
+                })))
+                .flatMap(device -> device.getModuleThing("module-a"))
+                .map(Thing::getId)
+                .as(StepVerifier::create)
+                .expectNext("test-module-provider:module-a")
+                .verifyComplete();
     }
 
     @Test


### PR DESCRIPTION
## 变更目的

为设备增加“模块”能力：模块归属于父设备，不作为子设备或独立物类型；支持模块编码、模块 Thing、模块级物模型、模块属性/事件存储查询，以及标准/官方协议模块 Topic。

## 设计边界

- 设备模块不是子设备，不参与独立认证、会话、在线、固件、子设备拓扑或独立权限。
- 模块物模型只继承父设备/产品 metadata 中 `modules[moduleCode]` 对应模块物模型。
- 模块操作走 `ThingModuleMessage` / `DeviceModuleMessage`。
- 模块属性/事件使用独立 row-shaped 表；column mode 下也回退到模块 row-shaped 表。
- 模块日志不单独建表，复用父设备日志。
- 事件值内部字段搜索 / JSONB 深度索引不是本次交付范围。
- 未改造协议包不自动支持模块消息。

## 验证

已在 detached clean worktrees 中仅应用设备模块 patch 并执行 PR 包级门禁：

```bash
bash .ai/device-module-release/run-pr-package-gates.sh
```

结果：

```text
OK: device module PR package gates passed on detached clean worktrees.
SUMMARY audit_mode=worktree-diff actual_diff_files=68 extra_files=0
OK: all diff files are within device module release file list.
```

覆盖：core/supports、device-manager、things-component、timescaledb Testcontainers、标准协议、官方协议、manifest、patch apply、自检与 diff 边界审计。

## 关联 PR

该能力为多仓库联动发布，请按依赖顺序合并：

1. jetlinks-core
2. jetlinks-supports
3. jetlinks-components
4. device-manager
5. jetlinks-protocols
6. jetlinks-official-protocol
7. jetlinks-ultimate 发布材料
