### PR TITLE
feat(device): 增加设备模块Thing契约

### DIFF
--- a/src/main/java/org/jetlinks/core/defaults/DefaultDeviceOperator.java
+++ b/src/main/java/org/jetlinks/core/defaults/DefaultDeviceOperator.java
@@ -34,6 +34,7 @@ import org.jetlinks.core.things.ThingRpcSupportChain;
 import org.jetlinks.core.utils.IdUtils;
 import org.jetlinks.core.utils.Reactors;
 import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.*;
@@ -92,6 +93,8 @@ public class DefaultDeviceOperator implements DeviceOperator, StorageConfigurabl
     @Setter
     private ThingRpcSupportChain rpcChain;
 
+    @Setter
+    private DeviceModuleThingProvider moduleThingProvider;
 
     public DefaultDeviceOperator(String id,
                                  ProtocolSupports supports,
@@ -198,6 +201,33 @@ public class DefaultDeviceOperator implements DeviceOperator, StorageConfigurabl
     @Override
     public String getDeviceId() {
         return id;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public Flux<DeviceModule> getModuleThings(String code) {
+        DeviceModuleThingProvider provider = moduleThingProvider;
+        if (provider == null) {
+            return DeviceOperator.super.getModuleThings(code);
+        }
+        return provider
+            .getModuleThings(this, code)
+            .switchIfEmpty(DeviceOperator.super.getModuleThings(code));
+    }
+
+    @Override
+    public Mono<DeviceModule> getModuleThing(String code, String instanceCode) {
+        DeviceModuleThingProvider provider = moduleThingProvider;
+        if (provider == null) {
+            return DeviceOperator.super.getModuleThing(code, instanceCode);
+        }
+        return provider
+            .getModuleThing(this, code, instanceCode)
+            .switchIfEmpty(DeviceOperator.super.getModuleThing(code, instanceCode));
     }
 
     @Override

--- a/src/main/java/org/jetlinks/core/device/DeviceModule.java
+++ b/src/main/java/org/jetlinks/core/device/DeviceModule.java
@@ -1,0 +1,35 @@
+package org.jetlinks.core.device;
+
+import org.jetlinks.core.things.Thing;
+
+/**
+ * 设备模块实例物操作对象.
+ * <p>
+ * 模块定义来自父设备/产品物模型中的 {@code modules[id]}, 模块实例来自具体设备的模块管理数据。
+ * 同一模块定义可在同一设备下创建多个模块实例。
+ *
+ * @author zhouhao
+ * @since 2.3.0
+ */
+public interface DeviceModule extends Thing {
+
+    /**
+     * @return 父设备ID
+     */
+    String getDeviceId();
+
+    /**
+     * 模块定义编码,对应物模型 {@code modules[id]}.
+     *
+     * @return 模块定义编码
+     */
+    String getCode();
+
+    /**
+     * 模块实例编码,用于区分同一设备下同一模块定义的多个实例.
+     *
+     * @return 模块实例编码
+     */
+    String getInstanceCode();
+
+}

--- a/src/main/java/org/jetlinks/core/device/DeviceModuleThingProvider.java
+++ b/src/main/java/org/jetlinks/core/device/DeviceModuleThingProvider.java
@@ -1,0 +1,40 @@
+package org.jetlinks.core.device;
+
+import org.jetlinks.core.things.Thing;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+/**
+ * 设备模块物提供器,用于为支持模块能力的设备运行时按模块编码创建模块 {@link Thing}.
+ *
+ * @author zhouhao
+ * @since 2.3.0
+ */
+public interface DeviceModuleThingProvider {
+
+    /**
+     * 获取设备下指定模块定义对应的所有模块实例物操作对象.
+     *
+     * @param device 父设备操作对象
+     * @param code   模块定义编码,对应物模型 {@code modules[id]}
+     * @return 模块实例物操作对象; 如果当前 provider 不支持此模块,可返回 {@link Flux#empty()}
+     */
+    Flux<DeviceModule> getModuleThings(DeviceOperator device, String code);
+
+    /**
+     * 获取设备下指定模块实例物操作对象.
+     *
+     * @param device       父设备操作对象
+     * @param code         模块定义编码,对应物模型 {@code modules[id]}
+     * @param instanceCode 模块实例编码
+     * @return 模块实例物操作对象; 如果当前 provider 不支持此模块实例,可返回 {@link Mono#empty()}
+     */
+    default Mono<DeviceModule> getModuleThing(DeviceOperator device, String code, String instanceCode) {
+        return getModuleThings(device, code)
+            .filter(module -> Objects.equals(module.getInstanceCode(), instanceCode))
+            .singleOrEmpty();
+    }
+
+}

--- a/src/main/java/org/jetlinks/core/device/DeviceOperator.java
+++ b/src/main/java/org/jetlinks/core/device/DeviceOperator.java
@@ -14,10 +14,12 @@ import org.jetlinks.core.principal.Principal;
 import org.jetlinks.core.server.session.DeviceSession;
 import org.jetlinks.core.things.Thing;
 import org.jetlinks.core.things.ThingType;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -37,6 +39,36 @@ public interface DeviceOperator extends Thing {
      * @return 设备ID
      */
     String getDeviceId();
+
+    /**
+     * 获取设备下指定模块定义对应的模块实例物操作对象.
+     * <p>
+     * 模块是设备内部的逻辑单元,不代表独立子设备。一个模块定义可在同一设备下存在多个实例,
+     * 因此按模块编码查询返回 {@link Flux}. 默认实现返回不支持,由具备模块能力的设备运行时覆盖。
+     *
+     * @param code 模块定义编码,对应物模型 {@code modules[id]}
+     * @return 模块实例物操作对象
+     * @see org.jetlinks.core.message.module.ThingModuleMessage
+     * @see org.jetlinks.core.message.module.DeviceModuleMessage
+     * @since 2.3.0
+     */
+    default Flux<DeviceModule> getModuleThings(String code) {
+        return Flux.error(new UnsupportedOperationException("unsupported device module"));
+    }
+
+    /**
+     * 获取设备下指定模块实例物操作对象.
+     *
+     * @param code         模块定义编码,对应物模型 {@code modules[id]}
+     * @param instanceCode 模块实例编码
+     * @return 模块实例物操作对象
+     * @since 2.3.0
+     */
+    default Mono<DeviceModule> getModuleThing(String code, String instanceCode) {
+        return getModuleThings(code)
+            .filter(module -> Objects.equals(module.getInstanceCode(), instanceCode))
+            .singleOrEmpty();
+    }
 
     /**
      * @return 当前设备连接所在服务器ID，如果设备未上线 {@link DeviceState#online}，则返回<code>null</code>

--- a/src/main/java/org/jetlinks/core/message/module/DefaultThingModuleMessage.java
+++ b/src/main/java/org/jetlinks/core/message/module/DefaultThingModuleMessage.java
@@ -8,6 +8,7 @@ public class DefaultThingModuleMessage extends CommonThingMessage<DefaultThingMo
     implements ThingModuleMessage {
 
     private String module;
+    private String moduleInstance;
     private Message message;
 
     @Override
@@ -23,6 +24,17 @@ public class DefaultThingModuleMessage extends CommonThingMessage<DefaultThingMo
     @Override
     public DefaultThingModuleMessage module(String module) {
         this.module = module;
+        return this;
+    }
+
+    @Override
+    public String getModuleInstance() {
+        return moduleInstance;
+    }
+
+    @Override
+    public DefaultThingModuleMessage moduleInstance(String instanceCode) {
+        this.moduleInstance = instanceCode;
         return this;
     }
 

--- a/src/main/java/org/jetlinks/core/message/module/DeviceModuleMessage.java
+++ b/src/main/java/org/jetlinks/core/message/module/DeviceModuleMessage.java
@@ -20,6 +20,7 @@ public class DeviceModuleMessage extends CommonDeviceMessage<DeviceModuleMessage
 
 
     private String module;
+    private String moduleInstance;
     private Message message;
 
     @Override
@@ -35,6 +36,17 @@ public class DeviceModuleMessage extends CommonDeviceMessage<DeviceModuleMessage
     @Override
     public DeviceModuleMessage module(String module) {
         this.module = module;
+        return this;
+    }
+
+    @Override
+    public String getModuleInstance() {
+        return moduleInstance;
+    }
+
+    @Override
+    public DeviceModuleMessage moduleInstance(String instanceCode) {
+        this.moduleInstance = instanceCode;
         return this;
     }
 

--- a/src/main/java/org/jetlinks/core/message/module/ThingModuleMessage.java
+++ b/src/main/java/org/jetlinks/core/message/module/ThingModuleMessage.java
@@ -36,6 +36,33 @@ public interface ThingModuleMessage extends ThingMessage {
     ThingModuleMessage module(String module);
 
     /**
+     * 模块实例编码.
+     * <p>
+     * 当消息来自旧版本或者单实例模块时可为空,此时模块实例编码默认等于 {@link #getModule()}。
+     *
+     * @return 模块实例编码
+     */
+    String getModuleInstance();
+
+    /**
+     * 设置模块实例编码.
+     *
+     * @param instanceCode 模块实例编码
+     * @return this
+     */
+    ThingModuleMessage moduleInstance(String instanceCode);
+
+    /**
+     * 获取有效模块实例编码.
+     *
+     * @return 如果 {@link #getModuleInstance()} 为空则返回 {@link #getModule()}
+     */
+    default String getModuleInstanceOrDefault() {
+        String instance = getModuleInstance();
+        return instance == null || instance.isEmpty() ? getModule() : instance;
+    }
+
+    /**
      * 模块消息
      *
      * @return 模块消息
@@ -54,6 +81,7 @@ public interface ThingModuleMessage extends ThingMessage {
     default void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         ThingMessage.super.readExternal(in);
         module(SerializeUtils.readNullableUTF(in));
+        moduleInstance(SerializeUtils.readNullableUTF(in));
         message((Message) SerializeUtils.readObject(in));
     }
 
@@ -61,6 +89,7 @@ public interface ThingModuleMessage extends ThingMessage {
     default void writeExternal(ObjectOutput out) throws IOException {
         ThingMessage.super.writeExternal(out);
         SerializeUtils.writeNullableUTF(getModule(), out);
+        SerializeUtils.writeNullableUTF(getModuleInstance(), out);
         SerializeUtils.writeObject(getMessage(), out);
     }
 }

--- a/src/main/java/org/jetlinks/core/things/ThingMetadata.java
+++ b/src/main/java/org/jetlinks/core/things/ThingMetadata.java
@@ -116,6 +116,7 @@ public interface ThingMetadata extends Metadata, Jsonable {
         json.put("functions", getFunctions().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("events", getEvents().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("tags", getTags().stream().map(Jsonable::toJson).collect(Collectors.toList()));
+        json.put("modules", getModules().stream().map(Jsonable::toJson).collect(Collectors.toList()));
         json.put("expands", getExpands());
         return json;
     }

--- a/src/test/java/org/jetlinks/core/defaults/DefaultDeviceOperatorTest.java
+++ b/src/test/java/org/jetlinks/core/defaults/DefaultDeviceOperatorTest.java
@@ -7,14 +7,19 @@ import org.jetlinks.core.message.*;
 import org.jetlinks.core.message.function.FunctionInvokeMessageReply;
 import org.jetlinks.core.message.interceptor.DeviceMessageSenderInterceptor;
 import org.jetlinks.core.message.property.ReadPropertyMessageReply;
+import com.alibaba.fastjson.JSONObject;
+import org.jetlinks.core.metadata.SimpleDeviceMetadata;
+import org.jetlinks.core.things.Thing;
 import org.jetlinks.core.utils.IdUtils;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 
 public class DefaultDeviceOperatorTest {
 
@@ -39,6 +44,84 @@ public class DefaultDeviceOperatorTest {
                 }
         );
     }
+
+    @Test
+    public void testGetModuleThingDefaultUnsupported() {
+        registry.register(DeviceInfo.builder()
+                                    .id("test-module-default")
+                                    .build())
+                .flatMapMany(device -> device.getModuleThings("module-a"))
+                .as(StepVerifier::create)
+                .expectError(UnsupportedOperationException.class)
+                .verify();
+    }
+
+    @Test
+    public void testGetModuleThingFromProvider() {
+        registry.register(DeviceInfo.builder()
+                                    .id("test-module-provider")
+                                    .build())
+                .cast(DefaultDeviceOperator.class)
+                .doOnNext(device -> device.setModuleThingProvider((parent, code) -> Flux.just(
+                    new TestDeviceModule(parent.getDeviceId(), code, "eth0"),
+                    new TestDeviceModule(parent.getDeviceId(), code, "eth1")
+                )))
+                .flatMapMany(device -> device.getModuleThings("network"))
+                .map(DeviceModule::getInstanceCode)
+                .as(StepVerifier::create)
+                .expectNext("eth0", "eth1")
+                .verifyComplete();
+    }
+
+    @Test
+    public void testGetModuleThingByInstanceFromProvider() {
+        registry.register(DeviceInfo.builder()
+                                    .id("test-module-provider-instance")
+                                    .build())
+                .cast(DefaultDeviceOperator.class)
+                .doOnNext(device -> device.setModuleThingProvider((parent, code) -> Flux.just(
+                    new TestDeviceModule(parent.getDeviceId(), code, "eth0"),
+                    new TestDeviceModule(parent.getDeviceId(), code, "eth1")
+                )))
+                .flatMap(device -> device.getModuleThing("network", "eth1"))
+                .map(DeviceModule::getId)
+                .as(StepVerifier::create)
+                .expectNext("test-module-provider-instance:eth1")
+                .verifyComplete();
+    }
+
+    @Test
+    public void testThingMetadataToJsonContainsModules() {
+        SimpleDeviceMetadata metadata = new SimpleDeviceMetadata();
+        metadata.setId("device");
+        metadata.setName("设备");
+
+        SimpleDeviceMetadata module = new SimpleDeviceMetadata();
+        module.setId("network");
+        module.setName("网络模块");
+
+        JSONObject json = new SimpleDeviceMetadata() {
+            @Override
+            public String getId() {
+                return metadata.getId();
+            }
+
+            @Override
+            public String getName() {
+                return metadata.getName();
+            }
+
+            @Override
+            public List<org.jetlinks.core.things.ThingMetadata> getModules() {
+                return Collections.singletonList(module);
+            }
+        }.toJson();
+
+        org.junit.Assert.assertTrue(json.containsKey("modules"));
+        org.junit.Assert.assertEquals(1, json.getJSONArray("modules").size());
+        org.junit.Assert.assertEquals("network", json.getJSONArray("modules").getJSONObject(0).getString("id"));
+    }
+
 
     @Test
     public void testParent(){
@@ -251,5 +334,122 @@ public class DefaultDeviceOperatorTest {
                 .expectNext(true)
                 .verifyComplete();
 
+    }
+
+    static class TestDeviceModule implements DeviceModule {
+        private final String deviceId;
+        private final String code;
+        private final String instanceCode;
+
+        TestDeviceModule(String deviceId, String code, String instanceCode) {
+            this.deviceId = deviceId;
+            this.code = code;
+            this.instanceCode = instanceCode;
+        }
+
+        @Override
+        public String getDeviceId() {
+            return deviceId;
+        }
+
+        @Override
+        public String getCode() {
+            return code;
+        }
+
+        @Override
+        public String getInstanceCode() {
+            return instanceCode;
+        }
+
+        @Override
+        public String getId() {
+            return deviceId + ":" + instanceCode;
+        }
+
+        @Override
+        public org.jetlinks.core.things.ThingType getType() {
+            return org.jetlinks.core.things.ThingType.of("device-module");
+        }
+
+        @Override
+        public Mono<? extends org.jetlinks.core.things.ThingTemplate> getTemplate() {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Void> resetMetadata() {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<? extends org.jetlinks.core.things.ThingMetadata> getMetadata() {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Boolean> updateMetadata(String metadata) {
+            return Mono.just(false);
+        }
+
+        @Override
+        public Mono<Boolean> updateMetadata(org.jetlinks.core.things.ThingMetadata metadata) {
+            return Mono.just(false);
+        }
+
+        @Override
+        public Mono<Value> getSelfConfig(String key) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Value> getConfig(String key) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<org.jetlinks.core.Values> getSelfConfigs(java.util.Collection<String> keys) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<org.jetlinks.core.Values> getConfigs(java.util.Collection<String> keys) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Boolean> setConfig(String key, Object value) {
+            return Mono.just(false);
+        }
+
+        @Override
+        public Mono<Boolean> setConfigs(java.util.Map<String, Object> conf) {
+            return Mono.just(false);
+        }
+
+        @Override
+        public Mono<Boolean> removeConfig(String key) {
+            return Mono.just(false);
+        }
+
+        @Override
+        public Mono<Value> getAndRemoveConfig(String key) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Boolean> removeConfigs(java.util.Collection<String> key) {
+            return Mono.just(false);
+        }
+
+        @Override
+        public Mono<Void> refreshConfig(java.util.Collection<String> keys) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Void> refreshAllConfig() {
+            return Mono.empty();
+        }
     }
 }

--- a/src/test/java/org/jetlinks/core/message/MessageTypeTest.java
+++ b/src/test/java/org/jetlinks/core/message/MessageTypeTest.java
@@ -5,6 +5,8 @@ import com.alibaba.fastjson.JSONObject;
 import lombok.SneakyThrows;
 import org.jetlinks.core.message.function.FunctionInvokeMessage;
 import org.jetlinks.core.message.property.ReadPropertyMessage;
+import org.jetlinks.core.message.module.DeviceModuleMessage;
+import org.jetlinks.core.message.module.ThingModuleMessage;
 import org.jetlinks.core.message.property.ReportPropertyMessage;
 import org.junit.Test;
 
@@ -113,6 +115,35 @@ public class MessageTypeTest {
         System.out.println(msg);
         assertEquals(msg.getDeviceId(), child.getDeviceId());
         assertEquals(msg.getChildDeviceMessage().toJson(), child.getChildDeviceMessage().toJson());
+    }
+
+
+    @Test
+    @SneakyThrows
+    public void testModuleMessageExternalizableKeepsModuleInstance() {
+        DeviceModuleMessage source = new DeviceModuleMessage();
+        source.deviceId("device-1");
+        source.messageId("module-msg");
+        source.module("network");
+        source.moduleInstance("eth0");
+        source.message(new ReportPropertyMessage()
+                           .deviceId("device-1")
+                           .messageId("inner-msg")
+                           .success(Collections.singletonMap("ip", "127.0.0.1")));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(out);
+        MessageType.writeExternal(source, output);
+        output.close();
+
+        ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()));
+        ThingModuleMessage message = (ThingModuleMessage) MessageType.readExternal(input);
+        assertEquals("device-1", message.getThingId());
+        assertEquals("network", message.getModule());
+        assertEquals("eth0", message.getModuleInstance());
+        assertEquals("eth0", message.getModuleInstanceOrDefault());
+        assertTrue(message.getMessage() instanceof ReportPropertyMessage);
+        assertEquals("inner-msg", message.getMessage().getMessageId());
     }
 
     @Test


### PR DESCRIPTION
## 本仓库范围

DeviceModule、DeviceModuleThingProvider、DeviceOperator 模块 Thing API、ThingMetadata modules 输出。

## 联动说明

本 PR 是设备模块能力多仓库联动发布的一部分。建议合并顺序：jetlinks-core -> jetlinks-supports -> jetlinks-components -> device-manager -> jetlinks-protocols。

---

# 设备模块能力生产发布

## 变更目的

为设备增加“模块”能力：模块归属于父设备，不作为子设备或独立物类型；模块可自定义编码，可通过 `DeviceOperator#getModuleThings(moduleCode)` 获取模块 `Thing`，并支持模块级物模型、读属性、写属性、功能调用、属性/事件历史存储与查询。

## 核心设计边界

1. 设备模块不是子设备，不参与独立认证、会话、在线状态、固件、子设备拓扑或独立资产权限。
2. 模块物模型只继承父设备/产品 metadata 中 `modules[moduleCode]` 对应模块物模型，不继承整机完整物模型。
3. 模块操作统一使用 `ThingModuleMessage` / `DeviceModuleMessage` 包装，内层属性、事件、功能 ID 不增加模块前缀。
4. 模块属性、模块事件使用独立 row-shaped 表；column mode 下模块数据也默认进入模块 row-shaped 表。
5. 模块日志不单独建表，继续复用父设备普通日志。
6. 模块数据查询提供专用 API，调用方不需要感知内部 `thingType`。
7. 事件值内部字段搜索不是本次交付能力；TimescaleDB `jsonb` 搜索为后续方言增强预留。
8. 未改造第三方/业务协议包不自动支持 `DeviceModuleMessage`，应按协议能力声明 unsupported 或能力缺失。

## 主要改动

- `dev/jetlinks/jetlinks-core`
  - `DeviceOperator#getModuleThings(moduleCode)` default unsupported。
  - `ThingMetadata#toJson()` 输出 `modules`。
  - 新增/接入 `DeviceModuleThingProvider`。

- `dev/jetlinks/jetlinks-supports`
  - `DefaultThingsMetadata` 支持 `modules` 解析、编码、copy、merge。
  - `ClusterDeviceRegistry` 接入模块 Thing provider。

- `modules/device-manager`
  - 新增 `DeviceModuleEntity`、`DeviceModuleService`、`DeviceModuleController`。
  - 新增 `DeviceModuleThing`、`DeviceModuleThingProvider`。
  - 新增 `DeviceModuleDataService`，提供模块属性/事件专用查询。
  - 模块 API 权限继承父设备资产权限。
  - 模块实例 metadata id 与模块编码一致性校验、`resetMetadata` 不存在模块 NotFound、重复模块编码友好错误。
  - 删除模块仅删除管理实体，不调用模块历史数据清理链路。
  - 补充 i18n、单元测试、设计/任务/发布文档。

- `jetlinks-components`
  - things-component 支持 `ThingModuleMessage` 模块属性/事件保存、查询、DDL、metric，并在模块属性/事件表中保留 `module` 与 `moduleInstance` 双维度。
  - column mode 下模块属性/事件默认进入模块 row-shaped 表。
  - timescaledb-component 支持模块表 DDL、模块维度索引和真实数据库验证。
  - configure-component 注册设备模块 provider。

- 协议包
  - 标准协议和官方协议支持 `/module/{moduleCode}/{instanceCode}/{innerTopic}`。
  - EventBus 完整设备消息 Topic 固定为 `/device/{productId}/{deviceId}/module/{moduleCode}/{instanceCode}/{innerTopic}`，单实例也必须显式包含 `{instanceCode}`。
  - 覆盖模块读属性、写属性、功能调用及 reply Topic。

## 历史数据策略

1. 删除模块管理实体不会物理删除已产生的模块属性、模块事件或父设备日志。
2. 模块历史数据仍按父设备 `deviceId`、产品表 `productId`、模块列 `module` 维度保留。
3. 未格式化历史事件查询可按 `deviceId + moduleCode + eventId` 查询已删除模块定义下的历史数据。
4. 格式化查询依赖当前父设备/产品物模型；模块定义删除后可能无法继续格式化历史值。

## 验证证据

### PR 包级 clean worktree 门禁

已在 detached clean worktree 上使用对齐后的目标基线重新执行：

```bash
DEVICE_MODULE_PR_BASE_REF_MAP='jetlinks-components=430b73d43' \
  bash .ai/device-module-release/run-pr-package-gates.sh
```

结果：`OK: device module PR package gates passed on detached clean worktrees.`

该门禁已覆盖 6 个 patch clean worktree apply、manifest 校验、发布 diff 边界审计、core/supports、device-manager、common/things、timescaledb、标准协议与官方协议测试。`jetlinks-components=430b73d43` 用于对齐 device-manager 既有 `CommonTagUtils` 依赖，不属于设备模块功能 patch。

已通过的发布材料边界证据：`verify-manifest.py` 输出 `patch_file_count=55`、`patch_not_in_release_count=0`，`status-summary.sh` 输出 `OK release materials are ready.`；同时已确认 EventBus topic 无 `/module/{code}/instance/{instanceCode}/...` 残留。

已通过测试：

```bash
./mvnw -f dev/jetlinks/pom.xml \
  -pl jetlinks-core,jetlinks-supports \
  -am \
  -Dtest=DefaultThingsMetadataModulesTest,DefaultDeviceOperatorTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

结果：`BUILD SUCCESS`，`DefaultDeviceOperatorTest` 11 个测试通过，`DefaultThingsMetadataModulesTest` 2 个测试通过。

```bash
./mvnw -pl modules/device-manager \
  -Dtest=DeviceModuleControllerTest,DeviceModuleDataServiceTest,DeviceModuleServiceTest,DeviceModuleThingTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

结果：`BUILD SUCCESS`，共 30 个测试通过。覆盖模块 CRUD/权限边界、metadata 合并与重置、重复编码与非法编码、运行时 Thing 包装、模块数据查询条件、删除模块保留历史数据调用边界。

```bash
./mvnw -pl jetlinks-components/things-component \
  -Dtest=ThingModuleMessageOperationsTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

结果：`BUILD SUCCESS`，`ThingModuleMessageOperationsTest` 11 个测试通过。

```bash
./mvnw -pl jetlinks-components/timescaledb-component \
  -am \
  -Dtest=TimescaleDBModuleDataStrategyTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

结果：`BUILD SUCCESS`，`TimescaleDBModuleDataStrategyTest` 1 个测试通过，Reactor 20 个模块 SUCCESS。该测试使用 Testcontainers 启动真实 TimescaleDB，覆盖模块表 DDL、索引、写入、查询和跨模块同名属性隔离，并断言不创建模块日志表。

```bash
./mvnw -f dev/jetlinks-protocols/jetlinks-protocol/pom.xml \
  -Dtest=StandardTopicMessageCodecTest \
  test
```

结果：`BUILD SUCCESS`，`StandardTopicMessageCodecTest` 10 个测试通过。

```bash
./mvnw -f dev/jetlinks-official-protocol/pom.xml \
  -Dtest=TopicMessageCodecTest \
  test
```

结果：`BUILD SUCCESS`，`TopicMessageCodecTest` 5 个测试通过。


### 2026-06-01 多实例 Topic 收口复核

本轮围绕 `/module/{code}/{instanceCode}/...` 与多实例模块模型重新生成发布 patch 和 manifest。

已通过：

```bash
python3 .ai/device-module-release/verify-manifest.py
bash .ai/device-module-release/status-summary.sh
bash .ai/device-module-release/self-test-apply-patches.sh
bash .ai/device-module-release/self-test-audit-release-diff.sh
```

结果摘要：`patch_file_count=55`、`patch_not_in_release_count=0`、`release_dependency_not_in_patch=-`，6 个 patch 均可在 detached clean worktree 上 `git apply --check`，diff 边界自检在 worktree/common-ref/per-repo-ref 三种模式下均为 `actual_diff_files=55 extra_files=0`。

针对性测试：

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  mvn -f dev/jetlinks/jetlinks-core/pom.xml \
  -Dtest=DefaultDeviceOperatorTest,MessageTypeTest -DskipITs -P'!develop' test

JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  mvn -f dev/jetlinks/jetlinks-supports/pom.xml \
  -Dtest=DefaultThingsMetadataModulesTest -DskipITs -P'!develop' test

JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  ./mvnw -pl modules/device-manager \
  -Dtest=DeviceModuleServiceTest,DeviceModuleThingTest,DeviceMessageConnectorTest,DeviceModuleDataServiceTest,DeviceModuleControllerTest,DeviceThingsDataCustomizerTest \
  -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -P'!develop' test
```

结果：core 21 个测试通过，supports 2 个测试通过，device-manager 50 个测试通过。

Topic/旧形态审计：未发现新增 `/module/{code}/instance/{instanceCode}`、`/module/{moduleCode}/instance/{instanceCode}` 或旧 `Mono<Thing> getModuleThing(String moduleCode)` API 正向残留；标准协议和官方协议均保留 `/module/*/*/**` 与 `/module/board/slot-1/...` 测试断言。

### 当前完整混合工作区完整矩阵补充

已执行：

```bash
bash .ai/device-module-release/verify-release.sh
```

结果：脚本内 core/supports、device-manager、things-component、timescaledb-component、标准协议、官方协议均 `BUILD SUCCESS`，输出 `========== 验证完成 ==========`。

注意：该证据来自当前完整混合工作区，只能作为功能闭环补充；若本 PR patch 继续在目标分支重放/合入，仍建议保留目标分支/CI 的 `run-release-gates.sh` 输出作为最终流水线记录。

### 正式发布分支要求

正式 PR 合并前，请在目标发布分支按实际门禁时机执行：

```bash
# patch 已应用但尚未提交：审计工作区 diff
bash .ai/device-module-release/run-release-gates.sh

# patch 已作为提交进入当前分支/CI：审计 <目标基线>...HEAD
DEVICE_MODULE_BASE_REF=<目标基线> bash .ai/device-module-release/run-release-gates.sh
```

如 CI 需要拆分步骤，可等价执行：

```bash
python3 .ai/device-module-release/verify-manifest.py
bash .ai/device-module-release/self-test-apply-patches.sh
bash .ai/device-module-release/verify-release.sh
bash .ai/device-module-release/self-test-audit-release-diff.sh
python3 .ai/device-module-release/audit-release-diff.py

# patch 已提交时，最后一步必须带 base ref 或设置 DEVICE_MODULE_BASE_REF
python3 .ai/device-module-release/audit-release-diff.py --base-ref <目标基线>
```

多仓库目标基线不一致时，应使用：

```bash
DEVICE_MODULE_BASE_REF_MAP='.=origin/2.10;modules/device-manager=origin/master;jetlinks-components=origin/master;dev/jetlinks/jetlinks-core=origin/master;dev/jetlinks/jetlinks-supports=origin/master;dev/jetlinks-protocols=origin/master;dev/jetlinks-official-protocol=origin/master' \
  bash .ai/device-module-release/run-release-gates.sh
```

并将输出结果补充到本 PR 描述或 CI 记录中。其中 `verify-manifest.py` 必须输出 `OK: release manifest verified.`，`self-test-apply-patches.sh` 必须输出全部 patch 正向或反向 `apply --check` 通过，`verify-release.sh` 必须全部 `BUILD SUCCESS`，`self-test-audit-release-diff.sh` 必须同时覆盖 `worktree-diff` 与 `committed-diff` 且输出 `actual_diff_files=55 extra_files=0`，`audit-release-diff.py` 必须输出 `extra_files=0`。如果 patch 已提交进入当前分支，`audit-release-diff.py` 还必须输出 `audit_mode=committed-diff` 和正确的 `base_ref` 或 `base_ref_map`。

## 文档同步

已同步：

- `modules/device-manager/docs/2026-05-30-device-module-design.md`
- `modules/device-manager/docs/2026-05-30-device-module-development-tasks.md`
- `modules/device-manager/docs/2026-05-30-device-module-release-notes.md`
- `modules/device-manager/docs/2026-05-30-device-module-release-file-list.md`

## 发布边界检查

本 PR 应只包含设备模块发布清单中的文件。不得混入：

- 集群/RPC、限流、指标/健康度、向量检索等无关组件改动。
- GB26875、大华、JTT809、SZY206 等非本次验证协议包改动。
- 微服务配置、静态资源、运行配置、临时文件等无关改动。

## 残余风险 / 非目标项

1. 未改造协议包不自动支持模块消息。
2. 事件值内部字段搜索未交付；如需支持，应单独实现 TimescaleDB/PostgreSQL `jsonb` 方言查询和索引验证。
3. 当前已有 controller 单元级权限短路验证，并覆盖删除模块不调用历史数据清理链路；如果组织门禁要求设备模块 controller 自身完整 HTTP/WebFlux 鉴权链路测试，需要额外补集成测试。


## 2026-06-02 补充验证记录

- 已将模块数据存储与查询补齐 `moduleInstance` 维度：保存行、DDL、查询条件、数据 ID 均包含模块实例编码。
- `QueryOperations` 保留旧单实例方法并委托到 `moduleInstance = module`，新增显式实例重载供 `DeviceModuleDataService` 调用。
- PR 包级 clean worktree 门禁已使用 `DEVICE_MODULE_PR_BASE_REF_MAP='jetlinks-components=430b73d43'` 通过，完整生产结论以该 clean worktree gate 与目标分支/CI 后续 `run-release-gates.sh` 为准。


补充通过的本地 targeted tests（2026-06-02）：

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  mvn -f jetlinks-components/pom.xml \
  -pl common-component,things-component \
  -Dtest=ThingModuleMessageOperationsTest \
  -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -P'!develop' test
```

结果：`BUILD SUCCESS`，`ThingModuleMessageOperationsTest` 14 个测试通过。

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  mvn -f jetlinks-components/pom.xml \
  -pl common-component,things-component \
  -DskipTests -DskipITs -P'!develop' install

JAVA_HOME=$(/usr/libexec/java_home -v 17) \
  ./mvnw -pl modules/device-manager \
  -Dtest=DeviceModuleDataServiceTest,DeviceMessageConnectorTest \
  -Dsurefire.failIfNoSpecifiedTests=false -DskipITs -P'!develop' test
```

结果：`BUILD SUCCESS`，`DeviceMessageConnectorTest` 5 个、`DeviceModuleDataServiceTest` 4 个测试通过。
