### PR TITLE
feat(codec): 增加uint1位数组编解码支持

### DIFF
--- a/src/main/java/org/jetlinks/core/codec/Codecs.java
+++ b/src/main/java/org/jetlinks/core/codec/Codecs.java
@@ -6,7 +6,9 @@ import org.jetlinks.core.cache.Caches;
 import org.jetlinks.core.codec.internal.*;
 import org.jetlinks.core.codec.internal.arrays.ArrayCodec;
 import org.jetlinks.core.codec.internal.arrays.BitArray;
+import org.jetlinks.core.codec.internal.arrays.LSBUInt1Array;
 import org.jetlinks.core.codec.internal.arrays.LSBBitArray;
+import org.jetlinks.core.codec.internal.arrays.UInt1Array;
 import org.jetlinks.core.codec.internal.bcd.*;
 import org.reactivestreams.Publisher;
 import org.springframework.core.ResolvableType;
@@ -138,6 +140,8 @@ public final class Codecs {
         Codec<java.time.LocalDateTime> BCD_DATE_TIME_12 = new BcdDateTime12();
         Codec<Boolean[]> BIT_ARRAY = new BitArray();
         Codec<Boolean[]> LSB_BIT_ARRAY = new LSBBitArray();
+        Codec<Integer[]> UINT1_ARRAY = new UInt1Array();
+        Codec<Integer[]> LSB_UINT1_ARRAY = new LSBUInt1Array();
     }
 
     private static Map<String, Codec<?>> mapping = new ConcurrentHashMap<>();
@@ -200,7 +204,9 @@ public final class Codecs {
             Internal.BCD_DATE_4_ARRAY,
             // 位数组
             Internal.BIT_ARRAY,
-            Internal.LSB_BIT_ARRAY
+            Internal.LSB_BIT_ARRAY,
+            Internal.UINT1_ARRAY,
+            Internal.LSB_UINT1_ARRAY
         );
     }
 

--- a/src/main/java/org/jetlinks/core/codec/internal/arrays/LSBUInt1Array.java
+++ b/src/main/java/org/jetlinks/core/codec/internal/arrays/LSBUInt1Array.java
@@ -1,0 +1,88 @@
+package org.jetlinks.core.codec.internal.arrays;
+
+import io.netty.buffer.ByteBuf;
+import org.jetlinks.core.codec.Codec;
+
+import javax.annotation.Nonnull;
+
+/**
+ * 将字节数组按位解析为无符号 1 位整数数组, 每个字节的 8 位从低位到高位(LSB first)依次转换.
+ */
+public class LSBUInt1Array implements Codec<Integer[]> {
+
+    @Override
+    public Class<Integer[]> forType() {
+        return Integer[].class;
+    }
+
+    @Override
+    public String getId() {
+        return "lsb_uint1_array";
+    }
+
+    @Override
+    public int byteLength() {
+        return -1;
+    }
+
+    @Override
+    public Integer[] decode(@Nonnull ByteBuf payload) {
+        int size = payload.readableBytes();
+        Integer[] result = new Integer[size * 8];
+        for (int i = 0; i < size; i++) {
+            byte b = payload.readByte();
+            int offset = i * 8;
+            result[offset] = (b & 0x01) != 0 ? 1 : 0;
+            result[offset + 1] = (b & 0x02) != 0 ? 1 : 0;
+            result[offset + 2] = (b & 0x04) != 0 ? 1 : 0;
+            result[offset + 3] = (b & 0x08) != 0 ? 1 : 0;
+            result[offset + 4] = (b & 0x10) != 0 ? 1 : 0;
+            result[offset + 5] = (b & 0x20) != 0 ? 1 : 0;
+            result[offset + 6] = (b & 0x40) != 0 ? 1 : 0;
+            result[offset + 7] = (b & 0x80) != 0 ? 1 : 0;
+        }
+        return result;
+    }
+
+    @Override
+    public ByteBuf encode(Integer[] body, ByteBuf buf) {
+        if (body == null || body.length == 0) {
+            return buf;
+        }
+
+        int size = body.length;
+        int fullBytes = size / 8;
+
+        for (int i = 0; i < fullBytes; i++) {
+            int offset = i * 8;
+            int b = 0;
+            if (isOne(body[offset])) b |= 0x01;
+            if (isOne(body[offset + 1])) b |= 0x02;
+            if (isOne(body[offset + 2])) b |= 0x04;
+            if (isOne(body[offset + 3])) b |= 0x08;
+            if (isOne(body[offset + 4])) b |= 0x10;
+            if (isOne(body[offset + 5])) b |= 0x20;
+            if (isOne(body[offset + 6])) b |= 0x40;
+            if (isOne(body[offset + 7])) b |= 0x80;
+            buf.writeByte(b);
+        }
+
+        int remaining = size % 8;
+        if (remaining > 0) {
+            int offset = fullBytes * 8;
+            int b = 0;
+            for (int i = 0; i < remaining; i++) {
+                if (isOne(body[offset + i])) {
+                    b |= (1 << i);
+                }
+            }
+            buf.writeByte(b);
+        }
+
+        return buf;
+    }
+
+    private boolean isOne(Integer value) {
+        return value != null && value != 0;
+    }
+}

--- a/src/main/java/org/jetlinks/core/codec/internal/arrays/UInt1Array.java
+++ b/src/main/java/org/jetlinks/core/codec/internal/arrays/UInt1Array.java
@@ -1,0 +1,88 @@
+package org.jetlinks.core.codec.internal.arrays;
+
+import io.netty.buffer.ByteBuf;
+import org.jetlinks.core.codec.Codec;
+
+import javax.annotation.Nonnull;
+
+/**
+ * 将字节数组按位解析为无符号 1 位整数数组, 每个字节的 8 位从高位到低位(MSB first)依次转换.
+ */
+public class UInt1Array implements Codec<Integer[]> {
+
+    @Override
+    public Class<Integer[]> forType() {
+        return Integer[].class;
+    }
+
+    @Override
+    public String getId() {
+        return "uint1_array";
+    }
+
+    @Override
+    public int byteLength() {
+        return -1;
+    }
+
+    @Override
+    public Integer[] decode(@Nonnull ByteBuf payload) {
+        int size = payload.readableBytes();
+        Integer[] result = new Integer[size * 8];
+        for (int i = 0; i < size; i++) {
+            byte b = payload.readByte();
+            int offset = i * 8;
+            result[offset] = (b & 0x80) != 0 ? 1 : 0;
+            result[offset + 1] = (b & 0x40) != 0 ? 1 : 0;
+            result[offset + 2] = (b & 0x20) != 0 ? 1 : 0;
+            result[offset + 3] = (b & 0x10) != 0 ? 1 : 0;
+            result[offset + 4] = (b & 0x08) != 0 ? 1 : 0;
+            result[offset + 5] = (b & 0x04) != 0 ? 1 : 0;
+            result[offset + 6] = (b & 0x02) != 0 ? 1 : 0;
+            result[offset + 7] = (b & 0x01) != 0 ? 1 : 0;
+        }
+        return result;
+    }
+
+    @Override
+    public ByteBuf encode(Integer[] body, ByteBuf buf) {
+        if (body == null || body.length == 0) {
+            return buf;
+        }
+
+        int size = body.length;
+        int fullBytes = size / 8;
+
+        for (int i = 0; i < fullBytes; i++) {
+            int offset = i * 8;
+            int b = 0;
+            if (isOne(body[offset])) b |= 0x80;
+            if (isOne(body[offset + 1])) b |= 0x40;
+            if (isOne(body[offset + 2])) b |= 0x20;
+            if (isOne(body[offset + 3])) b |= 0x10;
+            if (isOne(body[offset + 4])) b |= 0x08;
+            if (isOne(body[offset + 5])) b |= 0x04;
+            if (isOne(body[offset + 6])) b |= 0x02;
+            if (isOne(body[offset + 7])) b |= 0x01;
+            buf.writeByte(b);
+        }
+
+        int remaining = size % 8;
+        if (remaining > 0) {
+            int offset = fullBytes * 8;
+            int b = 0;
+            for (int i = 0; i < remaining; i++) {
+                if (isOne(body[offset + i])) {
+                    b |= (1 << (7 - i));
+                }
+            }
+            buf.writeByte(b);
+        }
+
+        return buf;
+    }
+
+    private boolean isOne(Integer value) {
+        return value != null && value != 0;
+    }
+}

--- a/src/test/java/org/jetlinks/core/codec/internal/arrays/LSBUInt1ArrayTest.java
+++ b/src/test/java/org/jetlinks/core/codec/internal/arrays/LSBUInt1ArrayTest.java
@@ -1,0 +1,58 @@
+package org.jetlinks.core.codec.internal.arrays;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LSBUInt1ArrayTest {
+
+    private final LSBUInt1Array codec = new LSBUInt1Array();
+
+    @Test
+    public void testForType() {
+        assertEquals(Integer[].class, codec.forType());
+    }
+
+    @Test
+    public void testGetId() {
+        assertEquals("lsb_uint1_array", codec.getId());
+    }
+
+    @Test
+    public void testDecodeSingleByte() {
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeByte(0x16);
+        Integer[] result = codec.decode(buf);
+        assertEquals(8, result.length);
+        assertEquals(Integer.valueOf(0), result[0]);
+        assertEquals(Integer.valueOf(1), result[1]);
+        assertEquals(Integer.valueOf(1), result[2]);
+        assertEquals(Integer.valueOf(0), result[3]);
+        assertEquals(Integer.valueOf(1), result[4]);
+        assertEquals(Integer.valueOf(0), result[5]);
+        assertEquals(Integer.valueOf(0), result[6]);
+        assertEquals(Integer.valueOf(0), result[7]);
+    }
+
+    @Test
+    public void testEncodeSingleByte() {
+        Integer[] bits = new Integer[]{0, 1, 1, 0, 1, 0, 0, 0};
+        ByteBuf buf = Unpooled.buffer();
+        codec.encode(bits, buf);
+        assertEquals(1, buf.readableBytes());
+        assertEquals(0x16, buf.readByte());
+    }
+
+    @Test
+    public void testRoundTrip() {
+        Integer[] bits = new Integer[]{1, 0, 1, 0, 1, 0, 1, 0, 0, 1};
+        ByteBuf buf = Unpooled.buffer();
+        codec.encode(bits, buf);
+        Integer[] decoded = codec.decode(buf);
+        for (int i = 0; i < bits.length; i++) {
+            assertEquals(bits[i], decoded[i]);
+        }
+    }
+}

--- a/src/test/java/org/jetlinks/core/codec/internal/arrays/UInt1ArrayTest.java
+++ b/src/test/java/org/jetlinks/core/codec/internal/arrays/UInt1ArrayTest.java
@@ -1,0 +1,58 @@
+package org.jetlinks.core.codec.internal.arrays;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UInt1ArrayTest {
+
+    private final UInt1Array codec = new UInt1Array();
+
+    @Test
+    public void testForType() {
+        assertEquals(Integer[].class, codec.forType());
+    }
+
+    @Test
+    public void testGetId() {
+        assertEquals("uint1_array", codec.getId());
+    }
+
+    @Test
+    public void testDecodeSingleByte() {
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeByte(0x16);
+        Integer[] result = codec.decode(buf);
+        assertEquals(8, result.length);
+        assertEquals(Integer.valueOf(0), result[0]);
+        assertEquals(Integer.valueOf(0), result[1]);
+        assertEquals(Integer.valueOf(0), result[2]);
+        assertEquals(Integer.valueOf(1), result[3]);
+        assertEquals(Integer.valueOf(0), result[4]);
+        assertEquals(Integer.valueOf(1), result[5]);
+        assertEquals(Integer.valueOf(1), result[6]);
+        assertEquals(Integer.valueOf(0), result[7]);
+    }
+
+    @Test
+    public void testEncodeSingleByte() {
+        Integer[] bits = new Integer[]{0, 0, 0, 1, 0, 1, 1, 0};
+        ByteBuf buf = Unpooled.buffer();
+        codec.encode(bits, buf);
+        assertEquals(1, buf.readableBytes());
+        assertEquals(0x16, buf.readByte());
+    }
+
+    @Test
+    public void testRoundTrip() {
+        Integer[] bits = new Integer[]{1, 0, 1, 0, 1, 0, 1, 0, 0, 1};
+        ByteBuf buf = Unpooled.buffer();
+        codec.encode(bits, buf);
+        Integer[] decoded = codec.decode(buf);
+        for (int i = 0; i < bits.length; i++) {
+            assertEquals(bits[i], decoded[i]);
+        }
+    }
+}


### PR DESCRIPTION
## 目的

- 为位数组场景新增直接输出 0/1 数组的 codec，避免下游必须先消费 Boolean[] 再二次转换
- 保持现有 bit_array 和 lsb_bit_array 语义不变，新增可选 codec 能力

## 核心变动

- 新增 `uint1_array`，按 MSB 顺序将位数组解码为 `Integer[]`
- 新增 `lsb_uint1_array`，按 LSB 顺序将位数组解码为 `Integer[]`
- 在 `Codecs` 中注册两个新 codec
- 新增对应单元测试，覆盖解码、编码和 round-trip 场景

## 测试结果

- 命令：`mvn -q -Dtest=BitArrayTest,LSBBitArrayTest,UInt1ArrayTest,LSBUInt1ArrayTest test`
- 单元测试：42 passed, 0 failed, 0 skipped

## 风险与说明

- 本次改动未修改现有 `bit_array` / `lsb_bit_array` 行为，兼容已有依赖
- 新增 codec 当前返回 `Integer[]`，用于承载 0/1 数值语义，便于后续映射到 `int` 或枚举物模型
