### PR TITLE
feat(protocol): 增加固件元数据解析契约

### DIFF
--- a/src/main/java/org/jetlinks/core/ProtocolSupport.java
+++ b/src/main/java/org/jetlinks/core/ProtocolSupport.java
@@ -171,12 +171,15 @@ public interface ProtocolSupport extends Disposable, Ordered, Comparable<Protoco
      * 解析固件包中的版本及协议私有元数据。
      * <p>
      * 调用方必须在返回的 {@link org.reactivestreams.Publisher} 终止前保持 {@code firmware} 资源有效。
-     * 实现必须关闭自行打开的流，且不得长期持有资源。发出结果表示成功解析；
+     * 实现必须关闭自行打开的流，且不得长期持有资源。实现涉及阻塞文件读取时，必须在返回链中
+     * 自行切换到允许阻塞的调度边界，调用方不会额外切换。发出结果表示成功解析，其中
+     * {@link FirmwareMetadata#getVersion()} 必须非空且非空白，协议私有 metadata 可为空；
      * {@link Mono#empty()} 表示当前协议不解析固件元数据；发出错误表示已识别固件但内容非法，
      * 错误由调用方处理且不会转入人工解析。默认实现不读取资源并返回空。
      *
      * @param firmware 待解析的固件资源，不可为空
-     * @return 固件元数据；空表示当前协议不解析，错误表示已识别固件但内容非法
+     * @return 固件元数据；成功结果的版本必须非空且非空白，空表示当前协议不解析，
+     * 错误表示已识别固件但内容非法
      * @since 1.3.2
      * @see FirmwareMetadata
      */

--- a/src/main/java/org/jetlinks/core/ProtocolSupport.java
+++ b/src/main/java/org/jetlinks/core/ProtocolSupport.java
@@ -13,7 +13,6 @@ import org.jetlinks.core.server.ClientConnection;
 import org.jetlinks.core.server.DeviceGatewayContext;
 import org.jetlinks.core.things.ThingRpcSupportChain;
 import org.springframework.core.Ordered;
-import org.springframework.core.io.Resource;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -170,20 +169,22 @@ public interface ProtocolSupport extends Disposable, Ordered, Comparable<Protoco
     /**
      * 解析固件包中的版本及协议私有元数据。
      * <p>
-     * 调用方必须在返回的 {@link org.reactivestreams.Publisher} 终止前保持 {@code firmware} 资源有效。
-     * 实现必须关闭自行打开的流，且不得长期持有资源。实现涉及阻塞文件读取时，必须在返回链中
-     * 自行切换到允许阻塞的调度边界，调用方不会额外切换。发出结果表示成功解析，其中
-     * {@link FirmwareMetadata#getVersion()} 必须非空且非空白，协议私有 metadata 可为空；
-     * {@link Mono#empty()} 表示当前协议不解析固件元数据；发出错误表示已识别固件但内容非法，
-     * 错误由调用方处理且不会转入人工解析。默认实现不读取资源并返回空。
+     * {@code context} 仅用于本次解析，协议实现不得缓存上下文或读取回调中获得的资源。
+     * 上下文负责关闭输入流及归档资源；协议实现只能在回调执行期间访问这些资源。
+     * 上下文读取操作同步且可能阻塞，阻塞调度边界由协议实现返回的 {@code Mono} 链负责。
+     * 发出结果表示成功解析，其中 {@link FirmwareMetadata#getVersion()} 必须非空且非空白，
+     * 协议私有 metadata 可为空；{@link Mono#empty()} 表示当前协议不解析固件元数据；
+     * 发出错误表示已识别固件但内容非法，错误由调用方处理且不会转入人工解析。
+     * 默认实现不读取上下文并返回空。
      *
-     * @param firmware 待解析的固件资源，不可为空
+     * @param context 本次固件元数据解析上下文，不可为空且不得缓存
      * @return 固件元数据；成功结果的版本必须非空且非空白，空表示当前协议不解析，
      * 错误表示已识别固件但内容非法
      * @since 1.3.2
      * @see FirmwareMetadata
+     * @see FirmwareMetadataContext
      */
-    default Mono<FirmwareMetadata> parseFirmwareMetadata(Resource firmware) {
+    default Mono<FirmwareMetadata> parseFirmwareMetadata(FirmwareMetadataContext context) {
         return Mono.empty();
     }
 

--- a/src/main/java/org/jetlinks/core/ProtocolSupport.java
+++ b/src/main/java/org/jetlinks/core/ProtocolSupport.java
@@ -13,6 +13,7 @@ import org.jetlinks.core.server.ClientConnection;
 import org.jetlinks.core.server.DeviceGatewayContext;
 import org.jetlinks.core.things.ThingRpcSupportChain;
 import org.springframework.core.Ordered;
+import org.springframework.core.io.Resource;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -163,6 +164,23 @@ public interface ProtocolSupport extends Disposable, Ordered, Comparable<Protoco
      * @since 1.1.2
      */
     default Mono<ConfigMetadata> getInitConfigMetadata() {
+        return Mono.empty();
+    }
+
+    /**
+     * 解析固件包中的版本及协议私有元数据。
+     * <p>
+     * 调用方必须在返回的 {@link org.reactivestreams.Publisher} 终止前保持 {@code firmware} 资源有效。
+     * 实现必须关闭自行打开的流，且不得长期持有资源。发出结果表示成功解析；
+     * {@link Mono#empty()} 表示当前协议不解析固件元数据；发出错误表示已识别固件但内容非法，
+     * 错误由调用方处理且不会转入人工解析。默认实现不读取资源并返回空。
+     *
+     * @param firmware 待解析的固件资源，不可为空
+     * @return 固件元数据；空表示当前协议不解析，错误表示已识别固件但内容非法
+     * @since 1.3.2
+     * @see FirmwareMetadata
+     */
+    default Mono<FirmwareMetadata> parseFirmwareMetadata(Resource firmware) {
         return Mono.empty();
     }
 

--- a/src/main/java/org/jetlinks/core/defaults/CompositeProtocolSupport.java
+++ b/src/main/java/org/jetlinks/core/defaults/CompositeProtocolSupport.java
@@ -89,6 +89,10 @@ public class CompositeProtocolSupport implements ProtocolSupport {
     private Function<DeviceProductOperator, Mono<Void>> onProductUnRegister;
     private Function<DeviceProductOperator, Mono<Void>> onProductMetadataChanged;
 
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private Function<FirmwareMetadataContext, Mono<FirmwareMetadata>> firmwareMetadataParser;
+
     private BiFunction<DeviceOperator, Flux<DeviceOperator>, Mono<Void>> onChildBind;
     private BiFunction<DeviceOperator, Flux<DeviceOperator>, Mono<Void>> onChildUnbind;
 
@@ -153,6 +157,25 @@ public class CompositeProtocolSupport implements ProtocolSupport {
 
     public void addMessageCodecSupport(DeviceMessageCodec codec) {
         addMessageCodecSupport(codec.getSupportTransport(), codec);
+    }
+
+    /**
+     * 注册固件元数据解析器，并声明协议支持固件升级。
+     *
+     * @param parser 固件元数据解析器，不可为空；返回语义与
+     *               {@link ProtocolSupport#parseFirmwareMetadata(FirmwareMetadataContext)} 一致
+     * @since 1.3.2
+     */
+    public void addFirmwareSupport(Function<FirmwareMetadataContext, Mono<FirmwareMetadata>> parser) {
+        this.firmwareMetadataParser = parser;
+        addFeature(DeviceFeatures.supportFirmware);
+    }
+
+    @Override
+    public Mono<FirmwareMetadata> parseFirmwareMetadata(FirmwareMetadataContext context) {
+        return firmwareMetadataParser == null
+            ? ProtocolSupport.super.parseFirmwareMetadata(context)
+            : firmwareMetadataParser.apply(context);
     }
 
     public void removeMessageCodecSupport(Transport transport) {

--- a/src/main/java/org/jetlinks/core/metadata/FirmwareMetadata.java
+++ b/src/main/java/org/jetlinks/core/metadata/FirmwareMetadata.java
@@ -1,0 +1,26 @@
+package org.jetlinks.core.metadata;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.jetlinks.core.ProtocolSupport;
+import org.springframework.core.io.Resource;
+
+import java.util.Map;
+
+/**
+ * 固件包中解析出的元数据。
+ * <p>
+ * {@link #version} 是固件包内真实版本的投影，{@link #metadata} 用于承载协议私有元数据。
+ * 本对象只描述解析结果，不负责元数据持久化，也不负责固件升级判断。
+ *
+ * @since 1.3.2
+ * @see ProtocolSupport#parseFirmwareMetadata(Resource)
+ */
+@Getter
+@Setter
+public class FirmwareMetadata {
+
+    private String version;
+
+    private Map<String, Object> metadata;
+}

--- a/src/main/java/org/jetlinks/core/metadata/FirmwareMetadata.java
+++ b/src/main/java/org/jetlinks/core/metadata/FirmwareMetadata.java
@@ -3,7 +3,6 @@ package org.jetlinks.core.metadata;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetlinks.core.ProtocolSupport;
-import org.springframework.core.io.Resource;
 
 import java.util.Map;
 
@@ -15,7 +14,7 @@ import java.util.Map;
  * 本对象只描述解析结果，不负责元数据持久化，也不负责固件升级判断。
  *
  * @since 1.3.2
- * @see ProtocolSupport#parseFirmwareMetadata(Resource)
+ * @see ProtocolSupport#parseFirmwareMetadata(FirmwareMetadataContext)
  */
 @Getter
 @Setter

--- a/src/main/java/org/jetlinks/core/metadata/FirmwareMetadata.java
+++ b/src/main/java/org/jetlinks/core/metadata/FirmwareMetadata.java
@@ -10,7 +10,8 @@ import java.util.Map;
 /**
  * 固件包中解析出的元数据。
  * <p>
- * {@link #version} 是固件包内真实版本的投影，{@link #metadata} 用于承载协议私有元数据。
+ * {@link #version} 是固件包内真实版本的投影，成功解析时必须非空且非空白；
+ * {@link #metadata} 用于承载协议私有元数据，可以为空。
  * 本对象只描述解析结果，不负责元数据持久化，也不负责固件升级判断。
  *
  * @since 1.3.2
@@ -20,7 +21,13 @@ import java.util.Map;
 @Setter
 public class FirmwareMetadata {
 
+    /**
+     * 固件包内的真实版本，成功解析时必填。
+     */
     private String version;
 
+    /**
+     * 协议私有元数据，可为空。
+     */
     private Map<String, Object> metadata;
 }

--- a/src/main/java/org/jetlinks/core/metadata/FirmwareMetadataContext.java
+++ b/src/main/java/org/jetlinks/core/metadata/FirmwareMetadataContext.java
@@ -1,0 +1,150 @@
+package org.jetlinks.core.metadata;
+
+import org.jetlinks.core.ProtocolSupport;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 固件元数据解析上下文。
+ * <p>
+ * 每个上下文只对应一次
+ * {@link ProtocolSupport#parseFirmwareMetadata(FirmwareMetadataContext)} 调用的解析生命周期。
+ * 协议实现不得缓存上下文、归档、条目或读取回调中获得的资源。输入流和归档资源只在对应
+ * 回调执行期间有效，并由上下文实现负责关闭。
+ * <p>
+ * 读取操作是同步且可能阻塞的，阻塞调度边界由协议实现返回的 {@code Mono} 链负责。
+ * 所有读取回调及其返回值均不可为 {@code null}。
+ *
+ * @since 1.3.2
+ * @see ProtocolSupport
+ */
+public interface FirmwareMetadataContext {
+
+    /**
+     * 获取当前固件文件的位置。
+     *
+     * @return 文件位置，不可为 {@code null}
+     */
+    String getFileLocation();
+
+    /**
+     * 读取固件文件内容。输入流只在 {@code reader} 回调执行期间有效，回调结束后由上下文实现关闭。
+     *
+     * @param reader 内容读取回调，不可为 {@code null}
+     * @param <T>    读取结果类型
+     * @return 回调返回的读取结果，不可为 {@code null}
+     * @throws IOException 读取或解析内容失败
+     */
+    <T> T readContent(ContentReader<T> reader) throws IOException;
+
+    /**
+     * 将固件文件作为归档读取。归档只在 {@code reader} 回调执行期间有效，回调结束后由上下文实现关闭。
+     *
+     * @param reader 归档读取回调，不可为 {@code null}
+     * @param <T>    读取结果类型
+     * @return 回调返回的读取结果；文件不是受支持的归档时返回 {@link Optional#empty()}，
+     * 此时不会调用 {@code reader}
+     * @throws IOException 已识别为归档但读取或解析失败
+     */
+    <T> Optional<T> readArchive(ArchiveReader<T> reader) throws IOException;
+
+    /**
+     * 文件内容读取回调。
+     *
+     * @param <T> 读取结果类型
+     * @since 1.3.2
+     */
+    @FunctionalInterface
+    interface ContentReader<T> {
+
+        /**
+         * 在输入流有效期内读取内容。
+         *
+         * @param stream 当前文件或归档条目的输入流，不可为 {@code null}，不得缓存
+         * @return 读取结果，不可为 {@code null}
+         * @throws IOException 读取或解析内容失败
+         */
+        T read(InputStream stream) throws IOException;
+    }
+
+    /**
+     * 归档读取回调。
+     *
+     * @param <T> 读取结果类型
+     * @since 1.3.2
+     */
+    @FunctionalInterface
+    interface ArchiveReader<T> {
+
+        /**
+         * 在归档有效期内读取条目。
+         *
+         * @param archive 当前归档，不可为 {@code null}，不得缓存
+         * @return 读取结果，不可为 {@code null}
+         * @throws IOException 读取或解析归档失败
+         */
+        T read(Archive archive) throws IOException;
+    }
+
+    /**
+     * 归档内容访问契约，仅在所属 {@link ArchiveReader} 回调执行期间有效。
+     *
+     * @since 1.3.2
+     */
+    interface Archive {
+
+        /**
+         * 获取归档中的全部条目。
+         * 返回列表保持归档中的原始顺序和重复条目，并包含目录条目。
+         *
+         * @return 有序条目列表，不可为 {@code null}
+         * @throws IOException 读取归档条目失败
+         */
+        List<? extends Entry> getEntries() throws IOException;
+
+        /**
+         * 读取指定条目的内容。输入流只在 {@code reader} 回调执行期间有效，回调结束后由上下文实现关闭。
+         *
+         * @param entry  当前归档通过 {@link #getEntries()} 返回的条目，不可为 {@code null}
+         * @param reader 内容读取回调，不可为 {@code null}
+         * @param <T>    读取结果类型
+         * @return 回调返回的读取结果，不可为 {@code null}
+         * @throws IOException 读取或解析条目失败
+         */
+        <T> T readContent(Entry entry, ContentReader<T> reader) throws IOException;
+
+        /**
+         * 将指定条目作为嵌套归档读取。嵌套归档只在 {@code reader} 回调执行期间有效，
+         * 回调结束后由上下文实现关闭。
+         *
+         * @param entry  当前归档通过 {@link #getEntries()} 返回的条目，不可为 {@code null}
+         * @param reader 归档读取回调，不可为 {@code null}
+         * @param <T>    读取结果类型
+         * @return 回调返回的读取结果；条目不是受支持的归档时返回 {@link Optional#empty()}，
+         * 此时不会调用 {@code reader}
+         * @throws IOException 已识别为归档但读取或解析失败
+         */
+        <T> Optional<T> readArchive(Entry entry, ArchiveReader<T> reader) throws IOException;
+    }
+
+    /**
+     * 归档条目，只在所属 {@link ArchiveReader} 回调执行期间有效。
+     *
+     * @since 1.3.2
+     */
+    interface Entry {
+
+        /**
+         * @return 归档中的条目名称，不可为 {@code null}
+         */
+        String getName();
+
+        /**
+         * @return 是否为目录条目
+         */
+        boolean isDirectory();
+    }
+}

--- a/src/test/java/org/jetlinks/core/ProtocolSupportTest.java
+++ b/src/test/java/org/jetlinks/core/ProtocolSupportTest.java
@@ -1,16 +1,11 @@
 package org.jetlinks.core;
 
 import org.jetlinks.core.device.TestProtocolSupport;
-import org.jetlinks.core.metadata.FirmwareMetadata;
 import org.jetlinks.core.metadata.FirmwareMetadataContext;
 import org.junit.Test;
 import reactor.test.StepVerifier;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Optional;
-
-import static org.junit.Assert.assertEquals;
 
 public class ProtocolSupportTest {
 
@@ -35,17 +30,5 @@ public class ProtocolSupportTest {
         StepVerifier
             .create(new TestProtocolSupport().parseFirmwareMetadata(context))
             .verifyComplete();
-    }
-
-    @Test
-    public void testFirmwareMetadata() {
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put("application", Map.of("releaseVersion", "2.12.0-SNAPSHOT"));
-        FirmwareMetadata firmwareMetadata = new FirmwareMetadata();
-        firmwareMetadata.setVersion("2.12.0-SNAPSHOT");
-        firmwareMetadata.setMetadata(metadata);
-
-        assertEquals("2.12.0-SNAPSHOT", firmwareMetadata.getVersion());
-        assertEquals(metadata, firmwareMetadata.getMetadata());
     }
 }

--- a/src/test/java/org/jetlinks/core/ProtocolSupportTest.java
+++ b/src/test/java/org/jetlinks/core/ProtocolSupportTest.java
@@ -2,12 +2,13 @@ package org.jetlinks.core;
 
 import org.jetlinks.core.device.TestProtocolSupport;
 import org.jetlinks.core.metadata.FirmwareMetadata;
+import org.jetlinks.core.metadata.FirmwareMetadataContext;
 import org.junit.Test;
-import org.springframework.core.io.ByteArrayResource;
 import reactor.test.StepVerifier;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
@@ -15,8 +16,24 @@ public class ProtocolSupportTest {
 
     @Test
     public void testParseFirmwareMetadataDefault() {
+        FirmwareMetadataContext context = new FirmwareMetadataContext() {
+            @Override
+            public String getFileLocation() {
+                return "test.bin";
+            }
+
+            @Override
+            public <T> T readContent(ContentReader<T> reader) {
+                throw new AssertionError("default implementation must not read firmware content");
+            }
+
+            @Override
+            public <T> Optional<T> readArchive(ArchiveReader<T> reader) {
+                throw new AssertionError("default implementation must not read firmware archive");
+            }
+        };
         StepVerifier
-            .create(new TestProtocolSupport().parseFirmwareMetadata(new ByteArrayResource(new byte[0])))
+            .create(new TestProtocolSupport().parseFirmwareMetadata(context))
             .verifyComplete();
     }
 

--- a/src/test/java/org/jetlinks/core/ProtocolSupportTest.java
+++ b/src/test/java/org/jetlinks/core/ProtocolSupportTest.java
@@ -1,0 +1,34 @@
+package org.jetlinks.core;
+
+import org.jetlinks.core.device.TestProtocolSupport;
+import org.jetlinks.core.metadata.FirmwareMetadata;
+import org.junit.Test;
+import org.springframework.core.io.ByteArrayResource;
+import reactor.test.StepVerifier;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ProtocolSupportTest {
+
+    @Test
+    public void testParseFirmwareMetadataDefault() {
+        StepVerifier
+            .create(new TestProtocolSupport().parseFirmwareMetadata(new ByteArrayResource(new byte[0])))
+            .verifyComplete();
+    }
+
+    @Test
+    public void testFirmwareMetadata() {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("application", Map.of("releaseVersion", "2.12.0-SNAPSHOT"));
+        FirmwareMetadata firmwareMetadata = new FirmwareMetadata();
+        firmwareMetadata.setVersion("2.12.0-SNAPSHOT");
+        firmwareMetadata.setMetadata(metadata);
+
+        assertEquals("2.12.0-SNAPSHOT", firmwareMetadata.getVersion());
+        assertEquals(metadata, firmwareMetadata.getMetadata());
+    }
+}

--- a/src/test/java/org/jetlinks/core/defaults/CompositeProtocolSupportTest.java
+++ b/src/test/java/org/jetlinks/core/defaults/CompositeProtocolSupportTest.java
@@ -1,0 +1,53 @@
+package org.jetlinks.core.defaults;
+
+import org.jetlinks.core.device.DeviceFeatures;
+import org.jetlinks.core.message.codec.DefaultTransport;
+import org.jetlinks.core.metadata.FirmwareMetadata;
+import org.jetlinks.core.metadata.FirmwareMetadataContext;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertSame;
+
+public class CompositeProtocolSupportTest {
+
+    @Test
+    public void testAddFirmwareSupport() {
+        CompositeProtocolSupport support = new CompositeProtocolSupport();
+        FirmwareMetadata metadata = new FirmwareMetadata();
+        metadata.setVersion("1.0.0");
+        FirmwareMetadataContext context = new FirmwareMetadataContext() {
+            @Override
+            public String getFileLocation() {
+                return "test.zip";
+            }
+
+            @Override
+            public <T> T readContent(ContentReader<T> reader) {
+                throw new AssertionError("parser controls firmware content access");
+            }
+
+            @Override
+            public <T> Optional<T> readArchive(ArchiveReader<T> reader) {
+                throw new AssertionError("parser controls firmware archive access");
+            }
+        };
+
+        support.addFirmwareSupport(actual -> {
+            assertSame(context, actual);
+            return Mono.just(metadata);
+        });
+
+        StepVerifier
+            .create(support.parseFirmwareMetadata(context))
+            .expectNext(metadata)
+            .verifyComplete();
+        StepVerifier
+            .create(support.getFeatures(DefaultTransport.MQTT))
+            .expectNext(DeviceFeatures.supportFirmware)
+            .verifyComplete();
+    }
+}


### PR DESCRIPTION
## 目的

- 为协议实现提供可选的固件元数据解析 SPI
- 通过平台 Context 统一文件、归档与嵌套归档访问，避免协议实现依赖 Spring 资源类型

## 核心变动

- 在 `ProtocolSupport` 增加 `parseFirmwareMetadata(FirmwareMetadataContext)`，默认返回 `Mono.empty()`
- 在 `CompositeProtocolSupport` 增加 `addFirmwareSupport(...)`，注册解析器时同步声明 `DeviceFeatures.supportFirmware`
- 新增 `FirmwareMetadataContext`，提供逻辑文件地址、原始内容读取、归档条目读取和嵌套 ZIP/JAR 读取契约
- 新增 `FirmwareMetadata`，包含真实版本和可选的协议私有 metadata
- 明确 result、empty、error 三态、Context 生命周期、异常传播和阻塞读取调度责任
- 明确普通非归档可返回 empty，已识别但损坏的 ZIP/JAR 必须报错且不得转入人工解析

## 设计与测试目标

- 设计稿：本地 `jetlinks-ultimate/docs/2026-07-15-固件升级完整开发设计.md`
- 用户确认：已确认，当前进入 Ready for review
- 测试目标：默认协议返回 empty 且不读取 Context；组合协议注册解析器后传递原 Context、返回解析结果并声明固件升级能力；下游覆盖文件、归档、嵌套 JAR、普通非归档与损坏归档
- 注释 / 公共契约：适用；SPI、Context 和组合协议注册方法已说明调用时机、三态、资源生命周期、错误传播、字段约束、阻塞调度责任，并补齐 `@since 1.3.2` 与 `@see`
- 数据权限：不适用；本仓库仅新增协议契约
- 数据库兼容与性能：不适用；不涉及持久化、SQL 或分页
- 链路追踪：不适用；纯 SPI 和结果对象，不新增运行时业务阶段
- MBean 运维可观测性：不适用；未新增常驻状态、缓存、队列或后台任务

## 测试结果

- 命令：`mvn -s 指定 settings -Dmaven.repo.local=指定本地仓库 -Dtest=CompositeProtocolSupportTest,ProtocolSupportTest test`
- 新增/更新测试：`CompositeProtocolSupportTest` 覆盖解析器注册、Context 透传、解析结果和 `supportFirmware` feature；`ProtocolSupportTest` 覆盖默认 empty 且不读取 Context
- 单元测试：2 passed, 0 failed, 0 errors, 0 skipped
- 下游契约测试：device-manager `FileFirmwareMetadataContextTest,ProtocolFirmwareServiceTest` 14 passed, 0 failed, 0 errors, 0 skipped；覆盖普通非归档返回 empty、按扩展名或 ZIP 签名识别的损坏归档抛错
- 集成测试：不适用；Core 仅提供纯契约和内存注册逻辑，不涉及数据库、消息、事件、远程服务或启动装配
- 压力测试：不适用；不涉及 SQL、批量、缓存或队列
- 覆盖率：本轮 `CompositeProtocolSupport` 新增 executable line 5/6（83.33%），branch 1/2（50%）；正常注册路径已覆盖，默认 SPI 行为由 `ProtocolSupportTest` 覆盖

## 文档同步情况

- 已同步：本地固件升级完整设计、实现说明和 Context 改造计划
- 未同步：本地整合文档按项目要求不提交到 Core 仓库
- 说明：README 长期总览未变化；测试证据保留在 PR

## 风险与说明

- 影响范围：`ProtocolSupport` 可选 SPI、`CompositeProtocolSupport` 注册入口、通用固件元数据 Context 与结果对象
- 注释 / 公共契约：已补 SPI 三态、Context/流/归档生命周期、组合协议注册语义、成功字段约束、阻塞调度责任、`@since` 与 `@see`
- 链路追踪 / 可观测性：不涉及；具体协议解析由协议侧既有调用链观测
- MBean / 运维可观测性：不涉及；未新增常驻资源
- 未覆盖场景：真实云端创建和 Edge 部署联调由下游 PR 承担
- 已知限制：Context 当前提供 ZIP/JAR 通用访问；普通非归档返回 empty，已识别但损坏的 ZIP/JAR 抛错；本 SPI 尚未发布，不保留旧 `Resource` 签名兼容层