### PR TITLE
perf(core): 优化 SharedPathString 追加性能

### DIFF
--- a/docs/plans/shared-path-string-performance.md
+++ b/docs/plans/shared-path-string-performance.md
@@ -1,0 +1,230 @@
+# SharedPathString 性能优化计划
+
+## 目标
+
+在保持 `SharedPathString`、`SeparatedCharSequence` 现有可观察语义的前提下，先建立可重复的
+JMH 基准，再优化设备消息 Topic 构造中的高频路径，并使用相同环境对比优化前后吞吐、时延和
+`gc.alloc.rate.norm`。
+
+## 影响范围
+
+- owning module：`jetlinks-core`
+- 重点代码：
+  - `src/main/java/org/jetlinks/core/lang/AbstractSeparatedCharSequence.java`
+  - `src/main/java/org/jetlinks/core/lang/AppendSeparatedCharSequence*.java`
+  - `src/main/java/org/jetlinks/core/lang/SharedPathString.java`
+  - `src/test/java/org/jetlinks/core/lang/SeparatedStringTest.java`
+  - 新增的 `src/test/java/org/jetlinks/core/benchmark/SharedPathStringBenchmark.java`
+- 设备场景验证参考：`DeviceMessageConnector` 使用的 property、online/offline、event、child
+  Topic 形状。
+
+## 保持不变的语义
+
+1. 不修改 `equals`、`hashCode`、`compareTo`、`contentEquals` 的既有定义。
+2. 不修改 `SharedPathString.of(String)`、`intern()`、split cache 和 segment intern 的既有语义。
+3. `append` 输入包含 `/`、以 `/` 开头、空字符串、字符分隔符时，生成的 segment、`size()`、
+   `get()`、`length()` 和 `toString()` 与当前实现一致。
+4. 不改变现有异常、序列化和具体 Topic 匹配行为；不引入新的公共 SPI。
+5. 不修改 EventBus 批量 API、Components 发布实现或 Device Manager 生产代码。
+
+## 不做什么
+
+- 本轮不修复 `empty().length()`、跨实现内容相等、数组可变性等既有契约问题。
+- 不移除或改造成有界 intern cache，不改变高基数 Topic 的缓存策略。
+- 不引入 ThreadLocal、对象池、scheduler 或响应式缓存。
+- 不以非 fork smoke 数据作为最终性能结论。
+
+## 实施步骤
+
+1. 增加独立 JMH 基准，覆盖：
+   - 静态后缀 property/status Topic；
+   - 动态单段 eventId/childDeviceId append；
+   - 含分隔符和前导分隔符的 append；
+   - append 深度 `1/4/8`；
+   - 构造、构造后 `hashCode()`、`contentEquals()`；
+   - intern 命中与不使用 intern 的解析对照。
+2. 在当前 HEAD 上使用固定 JDK、JVM 参数、fork/warmup/measurement 和 GC profiler 执行基准，
+   保存原始 JSON 作为基线。
+3. 根据基线只优化确认的热点。首选方案是在单 segment append 中避免不必要的完整 path split，
+   同时保留当前 segment intern 和包含分隔符时的既有解析行为；必要时缓存 composite 的稳定尺寸，
+   但不扩大改动范围。
+4. 补充行为等价测试，覆盖基准中的所有 Topic 形状，并校验 concrete class 相关的
+   `equals/hashCode/compareTo` 结果未变化。
+5. 在相同环境重新执行完整 JMH 矩阵，报告每个场景的 ns/op、B/op、变化百分比和误差区间；
+   再运行 core 定向测试与编译。
+
+## 风险与门禁
+
+- 最大风险是“单段 fast path”意外改变 segment intern、前导/尾部分隔符或多段展开语义；必须用
+  优化前结果快照和行为测试双重门禁。
+- JMH 必须使用独立 fork；non-fork 结果只用于发现热点。
+- 设备 property/status 当前已走结构化静态后缀路径，不允许为优化 event 动态段导致其吞吐或
+  B/op 明显回退。
+- 若优化仅改善微基准但增加完整 Topic 常驻内存，或正式多 fork 结果无稳定收益，则撤回生产改动，
+  只保留基准。
+
+## 验证方式
+
+- JMH：至少 2 fork、3 次 warmup、5 次 measurement、JDK 21、G1、固定堆，启用 `GCProfiler`；
+  关键场景补 JFR。
+- 单元测试：`SharedPathStringTest`、`SeparatedStringTest` 及新增语义回归。
+- 构建：`mvn -q -DskipTests compile` 和相关定向测试。
+- 结果完成后回填本文件，包括基线、优化后结果、最终代码落点和剩余风险。
+
+## 实施结果
+
+最终只修改 `AbstractSeparatedCharSequence.append(CharSequence)` 的单 segment 分支：输入先按原语义
+执行 `toString()` 快照；非空且不包含当前 separator 时直接执行 segment intern，不再调用完整 path
+split；空字符串、包含 separator 的字符串以及已经结构化的 `SeparatedCharSequence` 仍走原路径。
+
+该实现保留了以下可观察行为：
+
+- 单 segment 仍由 `RecyclerUtils.intern` 共享引用；
+- 返回类型仍为 `AppendSeparatedCharSequence`；
+- 多 segment、前导/尾随 separator 和空字符串的展开、`size()`、`get()`、`toString()` 不变；
+- 可变 `CharSequence` 仍在 append 时形成字符串快照；
+- `equals`、`hashCode`、`compareTo` 和 `contentEquals` 未修改。
+
+最终代码落点：
+
+- 生产优化：`src/main/java/org/jetlinks/core/lang/AbstractSeparatedCharSequence.java`
+- 行为回归：`src/test/java/org/jetlinks/core/lang/SeparatedStringTest.java`
+- 可重复基准：`src/test/java/org/jetlinks/core/benchmark/SharedPathStringBenchmark.java`
+
+本次不新增缓存、常驻任务或公共契约，因此不需要 MBean、TraceHolder 或 i18n 变更。
+
+## 正式 JMH 对比
+
+环境：macOS 15.7.4 x86_64、Temurin JDK 21.0.10、G1、`-Xms1g -Xmx1g`；每组
+2 fork、3 次 1 秒 warmup、5 次 1 秒 measurement，并启用 `GCProfiler`。表中误差为 JMH
+99.9% 置信区间；吞吐倍数由相同操作的 `baseline ns/op / optimized ns/op` 换算。
+
+| 场景 | 基线 ns/op | 优化后 ns/op | 时延下降 | 吞吐倍数 | B/op 基线→优化后 | 分配下降 |
+|---|---:|---:|---:|---:|---:|---:|
+| 单 segment append | 247.069 ± 4.210 | 28.841 ± 0.216 | 88.3% | 8.57x（+756.7%） | 160.007 → 24.001 | 85.0% |
+| 单 segment append + hash | 267.861 ± 8.554 | 46.276 ± 1.339 | 82.7% | 5.79x（+478.8%） | 160.007 → ≈0 | ≈100% |
+| device event Topic | 251.150 ± 9.715 | 42.246 ± 0.389 | 83.2% | 5.94x（+494.5%） | 232.010 → 96.004 | 58.6% |
+| device event Topic + hash | 272.102 ± 12.775 | 65.587 ± 0.649 | 75.9% | 4.15x（+314.9%） | 232.011 → 96.004 | 58.6% |
+| append depth 1 + hash | 240.333 ± 10.068 | 38.515 ± 1.086 | 84.0% | 6.24x（+524.0%） | 160.007 → 24.001 | 85.0% |
+| append depth 4 + hash | 1075.960 ± 74.013 | 225.092 ± 9.071 | 79.1% | 4.78x（+378.0%） | 640.026 → 96.004 | 85.0% |
+| append depth 8 + hash | 2449.212 ± 55.405 | 773.194 ± 56.716 | 68.4% | 3.17x（+216.8%） | 1280.059 → 192.009 | 85.0% |
+| 完整 path append | 710.074 ± 8.877 | 727.111 ± 9.638 | -2.4% | 0.98x（-2.3%） | 640.029 → 640.029 | 0% |
+| device property Topic | 9.069 ± 0.070 | 8.785 ± 0.124 | 3.1% | 1.03x（+3.2%） | 72.003 → 72.003 | 0% |
+| device property Topic + hash | 33.622 ± 1.490 | 32.225 ± 0.229 | 4.2% | 1.04x（+4.3%） | 72.003 → 72.003 | 0% |
+| shared parse | 55.293 ± 1.291 | 54.107 ± 1.048 | 2.1% | 1.02x（+2.2%） | 24.001 → 24.001 | 0% |
+| unshared parse | 472.451 ± 3.478 | 459.363 ± 11.371 | 2.8% | 1.03x（+2.8%） | 480.022 → 480.023 | 0% |
+| structured contentEquals | 883.837 ± 31.669 | 850.617 ± 6.879 | 3.8% | 1.04x（+3.9%） | ≈0 → ≈0 | 0% |
+
+结论：收益集中在预期的动态单 segment 热路径。property 静态后缀、parse 和
+`contentEquals` 没有结构性分配变化；完整 path append 不命中 fast path，B/op 完全不变，约
+2.3% 的吞吐差异按跨进程运行噪声处理，不扩大优化范围。
+
+## JFR 复核
+
+对优化后的 `appendSingleSegment`、`eventTopic` 各执行 1 fork、3 warmup、5 measurement 的
+JFR profile：
+
+- `appendSingleSegment` 的采样分配 99.82% 为最终结果对象
+  `AppendSeparatedCharSequence`；
+- `eventTopic` 的采样分配 99.89% 为既有 product/device 替换对象
+  `ReplacedSeparatedCharSequence2`；
+- 两个场景均未再出现 `TopicUtils.split` 所产生的临时数组、分段字符串和结构化 path 对象主导分配。
+
+JFR 与 `GCProfiler` 的 160 → 24 B/op、232 → 96 B/op 结论一致，说明收益来自删除单 segment
+场景的无效完整 path split，而不是调度、缓存或测量绕过。
+
+## 验证结果
+
+- 定向测试：`mvn -o -q -Dtest=SeparatedStringTest,SharedPathStringTest test`，12/12 通过；
+- 全量测试：`mvn -o -q test`，632 项，0 failure、0 error、1 skipped；
+- 编译：`mvn -o -q -DskipTests compile` 通过；
+- 格式：`git diff --check` 通过；
+- JaCoCo（全量测试后）：`AbstractSeparatedCharSequence` 行覆盖 89/121（73.6%），分支覆盖
+  61/90（67.8%）。
+
+原始基准 JSON 和 JFR 位于 `target/shared-path-string-benchmark/`，属于本地构建产物，不提交；
+正式数值已回填本文件。现有回归用例未发现语义变化；基准只代表 Topic 构造本身，端到端 EventBus 投递收益
+仍会受订阅匹配、序列化和消费端成本影响。
+
+## 第二阶段：Append 复合遍历优化计划
+
+目标限定在 `AppendSeparatedCharSequence` 和 `AppendSeparatedCharSequenceX` 形成的复合链：
+
+1. 补充 append 深度 `1/4/8` 的 `length()`、`toString()`、原始字符串 `contentEquals()` 基准，
+   与现有 `hashCode()` 深度基准共同建立优化前数据；
+2. 使用包内、无额外对象字段的 segment 线性遍历方法，避免 `hashCode()`、`toString()`、
+   `length()` 经由 `get(i)` 反复递归 source 链；
+3. 保持具体返回类型、对象大小、segment intern、hash 结果、前导空 segment 合并以及
+   `equals/compareTo/contentEquals` 结果不变；
+4. 不增加 `$size`、字符串/数组快照、Topic 缓存或节点压平，避免百万 Topic 场景增加常驻内存；
+5. 使用同一 JMH 参数对比深度场景，并以单段 append 的 24 B/op 不回退作为内存门禁。
+
+风险主要在 `AppendSeparatedCharSequenceX.ignoreFirst` 的前导空 segment 语义，以及 hash 必须以
+最外层具体 class 为 seed。实施前后将使用不同 separator、空段、多段 append、深度链和 hash
+快照测试共同校验。
+
+### 第二阶段实施结果
+
+最终实现没有增加任何对象字段：
+
+- `appendHash` 由 append 节点按 source → 当前 segment 顺序计算，保留最外层具体 class hash seed；
+- `contentLength` 和 `appendTo` 直接遍历 source 链，不再为每个索引重复调用递归 `get(i)`；
+- 原始字符串 `contentEquals` 改为按 segment 和字符单次比较，不再对每个字符重新执行
+  `this.charAt(i)` 的完整 segment 搜索；
+- 单层 append hash 保留原索引路径，使 JIT 仍能标量替换短生命周期节点；仅嵌套单段 append 链
+  使用线性 hash。全量线性 hash 的中间方案使 `appendSingleSegmentHash` 从 ≈0 增加到 24 B/op，
+  因此未保留。
+
+没有实施节点压平、`$size` 字段、字符串/数组快照或缓存；具体 class、对象大小和常驻内存不变。
+
+### 第二阶段正式 JMH 对比
+
+环境和参数与第一阶段相同：Temurin JDK 21.0.10、G1、固定 1 GiB 堆、2 fork、3 次 1 秒
+warmup、5 次 1 秒 measurement、`GCProfiler`。吞吐提升由基线与最终 ns/op 的倒数换算。
+
+| 操作 | 深度 | 基线 ns/op | 最终 ns/op | 时延下降 | 吞吐提升 | B/op 基线→最终 |
+|---|---:|---:|---:|---:|---:|---:|
+| contentEquals | 1 | 187.411 ± 6.769 | 57.426 ± 0.390 | 69.4% | 3.26x（+226.4%） | 24.001 → 24.001 |
+| contentEquals | 4 | 5602.941 ± 35.965 | 294.092 ± 5.894 | 94.8% | 19.05x（+1805.2%） | 96.032 → 96.005 |
+| contentEquals | 8 | 51187.030 ± 335.342 | 874.755 ± 59.942 | 98.3% | 58.52x（+5751.6%） | 194.299 → 192.010 |
+| hashCode | 1 | 38.530 ± 0.390 | 37.986 ± 0.184 | 1.4% | 1.01x（+1.4%） | 24.001 → 24.001 |
+| hashCode | 4 | 230.002 ± 3.480 | 135.571 ± 3.400 | 41.1% | 1.70x（+69.7%） | 96.004 → 96.004 |
+| hashCode | 8 | 791.434 ± 59.226 | 319.917 ± 1.951 | 59.6% | 2.47x（+147.4%） | 192.009 → 192.009 |
+| length | 1 | 32.475 ± 0.135 | 29.582 ± 0.403 | 8.9% | 1.10x（+9.8%） | 24.001 → 24.001 |
+| length | 4 | 226.474 ± 5.928 | 121.595 ± 0.802 | 46.3% | 1.86x（+86.3%） | 96.004 → 96.004 |
+| length | 8 | 799.527 ± 74.074 | 277.180 ± 2.310 | 65.3% | 2.88x（+188.5%） | 192.009 → 192.008 |
+| toString | 1 | 104.648 ± 6.082 | 105.488 ± 2.449 | -0.8% | 0.99x（-0.8%） | 96.004 → 96.004 |
+| toString | 4 | 325.584 ± 27.023 | 249.221 ± 2.710 | 23.5% | 1.31x（+30.6%） | 216.010 → 216.009 |
+| toString | 8 | 859.465 ± 46.995 | 487.849 ± 5.155 | 43.2% | 1.76x（+76.2%） | 384.017 → 384.017 |
+
+浅链与既有设备场景门禁：
+
+| 场景 | 基线 ns/op | 最终 ns/op | B/op 基线→最终 |
+|---|---:|---:|---:|
+| appendSingleSegment | 29.536 ± 0.642 | 29.264 ± 0.196 | 24.001 → 24.001 |
+| appendSingleSegmentHash | 45.408 ± 0.681 | 44.771 ± 0.457 | ≈0 → ≈0 |
+| eventTopic | 43.433 ± 0.351 | 43.740 ± 0.263 | 96.004 → 96.004 |
+| eventTopicHash | 65.716 ± 5.832 | 65.962 ± 0.625 | 96.004 → 96.004 |
+| appendFullPath | 747.221 ± 4.601 | 750.433 ± 6.103 | 640.026 → 640.026 |
+
+浅链差异均在约 ±1% 和置信区间内，没有结构性回退。深度 8 JFR 中，`contentEquals` 与
+`hashCode` 的采样分配分别有 98.28% 和 99.29% 来自必须创建的
+`AppendSeparatedCharSequence` 节点，未出现新的缓存、数组、遍历状态或字符串快照分配。
+
+### 第二阶段验证结果
+
+- 行为测试覆盖单/多 segment、自定义 separator、空段、`ignoreFirst`、可变输入快照、深度 8
+  链，以及按旧公式动态计算的 hash 结果；
+- 定向测试：`SeparatedStringTest`、`SharedPathStringTest` 共 12 项通过；
+- 全量测试：632 项，0 failure、0 error、1 skipped；
+- `mvn -o -q -DskipTests compile`、`git diff --check` 通过；
+- JaCoCo：`AbstractSeparatedCharSequence` 行 114/147、分支 77/108；
+  `AppendSeparatedCharSequence` 行 17/20；`AppendSeparatedCharSequenceX` 行 30/34。
+
+第二阶段原始数据位于本地构建目录：
+
+- `target/shared-path-string-benchmark/append-traversal-baseline.json`
+- `target/shared-path-string-benchmark/append-traversal-final.json`
+- `target/shared-path-string-benchmark/jfr-append-final/`
+
+这些构建产物不提交，正式结果已回填本文件。

--- a/docs/plans/shared-path-string-performance.md
+++ b/docs/plans/shared-path-string-performance.md
@@ -228,3 +228,8 @@ warmup、5 次 1 秒 measurement、`GCProfiler`。吞吐提升由基线与最终
 - `target/shared-path-string-benchmark/jfr-append-final/`
 
 这些构建产物不提交，正式结果已回填本文件。
+
+## 交付信息
+
+- 实现提交：`eb9b582a4b535ad2e4605c6a199cd02e66fc8ac5`
+- Pull Request：https://github.com/jetlinks/jetlinks-core/pull/96

--- a/src/main/java/org/jetlinks/core/lang/AbstractSeparatedCharSequence.java
+++ b/src/main/java/org/jetlinks/core/lang/AbstractSeparatedCharSequence.java
@@ -61,7 +61,13 @@ abstract class AbstractSeparatedCharSequence implements SeparatedCharSequence {
     @Override
     public SeparatedCharSequence append(CharSequence csq) {
         if (!(csq instanceof SeparatedCharSequence)) {
-            csq = SeparatedString.of(separator(), csq.toString());
+            String value = csq.toString();
+            if (!value.isEmpty() && value.indexOf(separator()) < 0) {
+                // 单 segment 是 Topic 构造热路径；保留原有 segment intern 语义，但避免完整 path split。
+                csq = RecyclerUtils.intern(value);
+            } else {
+                csq = SeparatedString.of(separator(), value);
+            }
         }
         if (csq instanceof SeparatedCharSequence) {
             return new AppendSeparatedCharSequenceX(this, (SeparatedCharSequence) csq);
@@ -122,14 +128,30 @@ abstract class AbstractSeparatedCharSequence implements SeparatedCharSequence {
         int h = $hash;
         if (h == 0) {
             h = this.getClass().hashCode();
-            int size = size();
-            if (size > 0) {
+            // 单层 append 保留索引遍历，便于 JIT 消除短生命周期节点；深链才使用线性遍历。
+            if (this instanceof AppendSeparatedCharSequence
+                && ((AppendSeparatedCharSequence) this).source instanceof AppendSeparatedCharSequence) {
+                h = appendHash(h);
+            } else {
+                int size = size();
+                char separator = separator();
                 for (int i = 0; i < size; i++) {
-                    h = 31 * h + get(i).hashCode() + separator();
+                    h = 31 * h + get(i).hashCode() + separator;
                 }
             }
         }
         return $hash = h;
+    }
+
+    // 深层复合序列覆盖此钩子，直接遍历 source，避免通过 get(i) 反复回溯 append 链。
+    int appendHash(int hash) {
+        int h = hash;
+        int size = size();
+        char separator = separator();
+        for (int i = 0; i < size; i++) {
+            h = 31 * h + get(i).hashCode() + separator;
+        }
+        return h;
     }
 
     @Override
@@ -190,9 +212,42 @@ abstract class AbstractSeparatedCharSequence implements SeparatedCharSequence {
     }
 
     @Override
+    public boolean contentEquals(CharSequence target) {
+        if (target instanceof SeparatedCharSequence) {
+            return SeparatedCharSequence.super.contentEquals(target);
+        }
+
+        int targetLen = target.length();
+        if (targetLen != length()) {
+            return false;
+        }
+
+        int offset = 0;
+        int size = size();
+        char separator = separator();
+        for (int i = 0; i < size; i++) {
+            if (i > 0 && target.charAt(offset++) != separator) {
+                return false;
+            }
+            CharSequence segment = get(i);
+            for (int j = 0, segmentLength = segment.length(); j < segmentLength; j++) {
+                if (target.charAt(offset++) != segment.charAt(j)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
     public int length() {
+        return contentLength();
+    }
+
+    int contentLength() {
         int len = 0;
-        for (int i = 0; i < size(); i++) {
+        int size = size();
+        for (int i = 0; i < size; i++) {
             len += get(i).length();
             len++;
         }
@@ -231,17 +286,20 @@ abstract class AbstractSeparatedCharSequence implements SeparatedCharSequence {
 
         return StringBuilderUtils.buildString(
             this,
-            (self, sb) -> {
-                char sp = self.separator();
-                int index = 0;
-                int size = self.size();
-                for (int i = index; i < size; i++) {
-                    if (i > index) {
-                        sb.append(sp);
-                    }
-                    sb.append(self.get(i));
-                }
-            });
+            (self, sb) -> self.appendTo(sb, 0));
+    }
+
+    int appendTo(StringBuilder builder, int segmentIndex) {
+        // 返回全局 segment 索引，使嵌套 append 无需压平也能保持分隔符位置。
+        char separator = separator();
+        int size = size();
+        for (int i = 0; i < size; i++) {
+            if (segmentIndex++ > 0) {
+                builder.append(separator);
+            }
+            builder.append(get(i));
+        }
+        return segmentIndex;
     }
 
     public AbstractSeparatedCharSequence intern() {

--- a/src/main/java/org/jetlinks/core/lang/AppendSeparatedCharSequence.java
+++ b/src/main/java/org/jetlinks/core/lang/AppendSeparatedCharSequence.java
@@ -41,4 +41,25 @@ class AppendSeparatedCharSequence extends AbstractSeparatedCharSequence {
         return source.get(index);
     }
 
+    @Override
+    int appendHash(int hash) {
+        int sourceHash = source.appendHash(hash);
+        return 31 * sourceHash + append.hashCode() + separator();
+    }
+
+    @Override
+    int contentLength() {
+        return source.contentLength() + append.length() + 1;
+    }
+
+    @Override
+    int appendTo(StringBuilder builder, int segmentIndex) {
+        segmentIndex = source.appendTo(builder, segmentIndex);
+        if (segmentIndex++ > 0) {
+            builder.append(separator());
+        }
+        builder.append(append);
+        return segmentIndex;
+    }
+
 }

--- a/src/main/java/org/jetlinks/core/lang/AppendSeparatedCharSequenceX.java
+++ b/src/main/java/org/jetlinks/core/lang/AppendSeparatedCharSequenceX.java
@@ -48,4 +48,36 @@ class AppendSeparatedCharSequenceX extends AbstractSeparatedCharSequence {
         }
         return source.get(index);
     }
+
+    @Override
+    int appendHash(int hash) {
+        int h = source.appendHash(hash);
+        char separator = separator();
+        for (int i = ignoreFirst ? 1 : 0, size = append.size(); i < size; i++) {
+            h = 31 * h + append.get(i).hashCode() + separator;
+        }
+        return h;
+    }
+
+    @Override
+    int contentLength() {
+        int length = source.contentLength();
+        for (int i = ignoreFirst ? 1 : 0, size = append.size(); i < size; i++) {
+            length += append.get(i).length() + 1;
+        }
+        return length;
+    }
+
+    @Override
+    int appendTo(StringBuilder builder, int segmentIndex) {
+        segmentIndex = source.appendTo(builder, segmentIndex);
+        char separator = separator();
+        for (int i = ignoreFirst ? 1 : 0, size = append.size(); i < size; i++) {
+            if (segmentIndex++ > 0) {
+                builder.append(separator);
+            }
+            builder.append(append.get(i));
+        }
+        return segmentIndex;
+    }
 }

--- a/src/test/java/org/jetlinks/core/benchmark/SharedPathStringBenchmark.java
+++ b/src/test/java/org/jetlinks/core/benchmark/SharedPathStringBenchmark.java
@@ -1,0 +1,209 @@
+package org.jetlinks.core.benchmark;
+
+import org.jetlinks.core.lang.SeparatedCharSequence;
+import org.jetlinks.core.lang.SharedPathString;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link SharedPathString} 设备 Topic 构造基准。
+ *
+ * 基准分别保留静态后缀、动态单段后缀、完整路径追加和字符串解析场景，避免只优化
+ * eventId 后掩盖 property/status 等既有快路径回退。
+ */
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 2, jvmArgsAppend = {"-Xms1g", "-Xmx1g", "-XX:+UseG1GC"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class SharedPathStringBenchmark {
+
+    @State(Scope.Thread)
+    public static class TopicState {
+
+        private static final SharedPathString DEVICE_TEMPLATE =
+            SharedPathString.of("/device/*/*", false);
+        private static final SharedPathString PROPERTY_SUFFIX =
+            SharedPathString.of("/message/property/report", false);
+        private static final SharedPathString EVENT_SUFFIX =
+            SharedPathString.of("/message/event", false);
+
+        String productId;
+        String deviceId;
+        String eventId;
+        String fullEventTopic;
+        SeparatedCharSequence eventPrefix;
+        SeparatedCharSequence eventTopic;
+
+        @Setup
+        public void setup() {
+            productId = "product-001";
+            deviceId = "device-000001";
+            eventId = "temperature_alarm";
+            fullEventTopic =
+                "/device/product-001/device-000001/message/event/temperature_alarm";
+            eventPrefix = DEVICE_TEMPLATE
+                .replace(2, productId, 3, deviceId)
+                .append(EVENT_SUFFIX);
+            eventTopic = eventPrefix.append(eventId);
+
+            // sharedParse 命中场景不混入首次解析和缓存填充成本。
+            SharedPathString.of(fullEventTopic);
+        }
+
+        SeparatedCharSequence propertyTopic() {
+            return DEVICE_TEMPLATE
+                .replace(2, productId, 3, deviceId)
+                .append(PROPERTY_SUFFIX);
+        }
+
+        SeparatedCharSequence eventTopic() {
+            return DEVICE_TEMPLATE
+                .replace(2, productId, 3, deviceId)
+                .append(EVENT_SUFFIX)
+                .append(eventId);
+        }
+
+    }
+
+    @State(Scope.Thread)
+    public static class AppendDepthState {
+
+        private static final SharedPathString BASE = SharedPathString.of("/device", false);
+
+        @Param({"1", "4", "8"})
+        int appendDepth;
+
+        String segment;
+        String expected;
+
+        @Setup
+        public void setup() {
+            segment = "temperature_alarm";
+            StringBuilder builder = new StringBuilder(BASE.toString());
+            for (int i = 0; i < appendDepth; i++) {
+                builder.append('/').append(segment);
+            }
+            expected = builder.toString();
+        }
+
+        SeparatedCharSequence appendByDepth() {
+            SeparatedCharSequence topic = BASE;
+            for (int i = 0; i < appendDepth; i++) {
+                topic = topic.append(segment);
+            }
+            return topic;
+        }
+    }
+
+    @Benchmark
+    public SeparatedCharSequence propertyTopic(TopicState state) {
+        return state.propertyTopic();
+    }
+
+    @Benchmark
+    public int propertyTopicHash(TopicState state) {
+        return state.propertyTopic().hashCode();
+    }
+
+    @Benchmark
+    public SeparatedCharSequence eventTopic(TopicState state) {
+        return state.eventTopic();
+    }
+
+    @Benchmark
+    public int eventTopicHash(TopicState state) {
+        return state.eventTopic().hashCode();
+    }
+
+    @Benchmark
+    public SeparatedCharSequence appendSingleSegment(TopicState state) {
+        return state.eventPrefix.append(state.eventId);
+    }
+
+    @Benchmark
+    public int appendSingleSegmentHash(TopicState state) {
+        return state.eventPrefix.append(state.eventId).hashCode();
+    }
+
+    @Benchmark
+    public SeparatedCharSequence appendFullPath(TopicState state) {
+        return SharedPathString
+            .of("/device/product-001/device-000001", false)
+            .append("/message/event/temperature_alarm");
+    }
+
+    @Benchmark
+    public int appendDepthHash(AppendDepthState state) {
+        return state.appendByDepth().hashCode();
+    }
+
+    @Benchmark
+    public int appendDepthLength(AppendDepthState state) {
+        return state.appendByDepth().length();
+    }
+
+    @Benchmark
+    public String appendDepthToString(AppendDepthState state) {
+        return state.appendByDepth().toString();
+    }
+
+    @Benchmark
+    public boolean appendDepthContentEquals(AppendDepthState state) {
+        return state.appendByDepth().contentEquals(state.expected);
+    }
+
+    @Benchmark
+    public SharedPathString sharedParse(TopicState state) {
+        return SharedPathString.of(state.fullEventTopic);
+    }
+
+    @Benchmark
+    public SharedPathString unsharedParse(TopicState state) {
+        return SharedPathString.of(state.fullEventTopic, false);
+    }
+
+    @Benchmark
+    public boolean structuredContentEquals(TopicState state) {
+        return state.eventTopic.contentEquals(state.fullEventTopic);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        String resultName = args.length == 0 ? "benchmark" : args[0];
+        boolean quick = args.length > 1 && Boolean.parseBoolean(args[1]);
+        File resultDirectory = new File("target/shared-path-string-benchmark");
+        resultDirectory.mkdirs();
+
+        OptionsBuilder options = new OptionsBuilder();
+        options
+            .include(SharedPathStringBenchmark.class.getSimpleName())
+            .forks(quick ? 1 : 2)
+            .warmupIterations(quick ? 1 : 3)
+            .warmupTime(TimeValue.seconds(1))
+            .measurementIterations(quick ? 2 : 5)
+            .measurementTime(TimeValue.seconds(1))
+            .addProfiler(GCProfiler.class)
+            .result(new File(resultDirectory, resultName + ".json").getPath())
+            .resultFormat(ResultFormatType.JSON);
+
+        new Runner(options.build()).run();
+    }
+}

--- a/src/test/java/org/jetlinks/core/lang/SeparatedStringTest.java
+++ b/src/test/java/org/jetlinks/core/lang/SeparatedStringTest.java
@@ -166,6 +166,93 @@ public class SeparatedStringTest {
     }
 
     @Test
+    public void testAppendCompatibility() {
+        SharedPathString source = SharedPathString.of("/device/product/device", false);
+
+        String segment1 = new String("temperature_alarm");
+        String segment2 = new String("temperature_alarm");
+        SeparatedCharSequence appended1 = source.append(segment1);
+        SeparatedCharSequence appended2 = source.append(segment2);
+
+        assertEquals(AppendSeparatedCharSequence.class, appended1.getClass());
+        assertEquals("/device/product/device/temperature_alarm", appended1.toString());
+        assertEquals(5, appended1.size());
+        // 单段 append 现有语义会共享内容相同的 segment 引用。
+        assertSame(appended1.get(4), appended2.get(4));
+        assertEquals(appended1, appended2);
+        assertEquals(appended1.hashCode(), appended2.hashCode());
+        assertEquals(0, appended1.compareTo(appended2));
+
+        assertAppendResult(source, "", "/device/product/device/", 5,
+                           AppendSeparatedCharSequence.class);
+        assertAppendResult(source, "/", "/device/product/device/", 5,
+                           AppendSeparatedCharSequence.class);
+        assertAppendResult(source, "/message/event", "/device/product/device/message/event", 6,
+                           AppendSeparatedCharSequenceX.class);
+        assertAppendResult(source, "message/event", "/device/product/device/message/event", 6,
+                           AppendSeparatedCharSequenceX.class);
+        assertAppendResult(source, "message/event/", "/device/product/device/message/event", 6,
+                           AppendSeparatedCharSequenceX.class);
+        assertAppendResult(source, "/message/event/", "/device/product/device/message/event", 6,
+                           AppendSeparatedCharSequenceX.class);
+
+        SeparatedCharSequence customSeparator = SeparatedString.create('|', "left", "right");
+        assertAppendResult(customSeparator, "dynamic", "left|right|dynamic", 3,
+                           AppendSeparatedCharSequence.class);
+        assertAppendResult(customSeparator, "dynamic|next", "left|right|dynamic|next", 4,
+                           AppendSeparatedCharSequenceX.class);
+
+        StringBuilder mutable = new StringBuilder("event_before_mutation");
+        SeparatedCharSequence snapshot = source.append(mutable);
+        mutable.setLength(0);
+        mutable.append("event_after_mutation");
+        assertEquals("/device/product/device/event_before_mutation", snapshot.toString());
+
+        SeparatedCharSequence eventTopic = source
+            .append(SharedPathString.of("/message/event", false))
+            .append("temperature_alarm");
+        String expectedEventTopic = "/device/product/device/message/event/temperature_alarm";
+        assertEquals(expectedEventTopic, eventTopic.toString());
+        assertEquals(expectedEventTopic.length(), eventTopic.length());
+        assertTrue(eventTopic.contentEquals(expectedEventTopic));
+        assertFalse(eventTopic.contentEquals(
+            "/device/product/device/message/event/temperature_alarx"));
+        assertEquals(calculateLegacyHash(eventTopic), eventTopic.hashCode());
+
+        SeparatedCharSequence deep = SharedPathString.of("/device", false);
+        for (int i = 0; i < 8; i++) {
+            deep = deep.append("temperature_alarm");
+        }
+        String expectedDeep = "/device"
+            + "/temperature_alarm".repeat(8);
+        assertEquals(AppendSeparatedCharSequence.class, deep.getClass());
+        assertEquals(10, deep.size());
+        assertEquals(expectedDeep, deep.toString());
+        assertEquals(expectedDeep.length(), deep.length());
+        assertTrue(deep.contentEquals(expectedDeep));
+        assertEquals(calculateLegacyHash(deep), deep.hashCode());
+    }
+
+    private static int calculateLegacyHash(SeparatedCharSequence sequence) {
+        int hash = sequence.getClass().hashCode();
+        for (int i = 0, size = sequence.size(); i < size; i++) {
+            hash = 31 * hash + sequence.get(i).hashCode() + sequence.separator();
+        }
+        return hash;
+    }
+
+    private static void assertAppendResult(SeparatedCharSequence source,
+                                           String append,
+                                           String expected,
+                                           int expectedSize,
+                                           Class<?> expectedType) {
+        SeparatedCharSequence actual = source.append(append);
+        assertEquals(expectedType, actual.getClass());
+        assertEquals(expected, actual.toString());
+        assertEquals(expectedSize, actual.size());
+    }
+
+    @Test
     public void test3() {
         String str = "test/1/2";
 


### PR DESCRIPTION
## 目的

- 优化 `SharedPathString` 动态单段追加与深层复合序列遍历性能。
- 降低设备事件 Topic 构造中的临时对象分配，并避免 `hashCode`、`length`、`toString`、`contentEquals` 随 append 深度重复回溯。

## 核心变动

- `core/lang`：单 segment append 保留字符串快照与 segment intern 语义，跳过不必要的完整 path split。
- `core/lang`：为 append 复合节点增加无额外对象字段的线性 hash、长度计算和字符串拼接路径；原始字符串 `contentEquals` 改为按 segment 单次扫描。
- `core/test`：补充空段、多分隔符、自定义分隔符、可变输入快照、具体类型、hash 与深链兼容性回归。
- `core/benchmark`：新增可重复 JMH 基准，覆盖真实设备 property/event Topic、单段/完整 path 追加及深度 1/4/8 场景。

## 设计与测试目标

- 设计稿：`docs/plans/shared-path-string-performance.md`
- 用户确认：已确认
- 测试目标：真实设备 Topic、正常路径、回归路径和边界路径均已覆盖；包括单/多 segment、空段、前后分隔符、自定义 separator、可变输入快照及深度 append 链。
- 注释 / 公共契约：不涉及公共 API 或 SPI 变更；性能分支的选择原因和深链遍历边界已在代码旁补充注释。
- 数据权限：不适用；未涉及资产、查询或操作权限。
- 数据库兼容与性能：不适用；未涉及数据库或 SQL。
- 链路追踪：不适用；仅修改 core 内部字符序列计算，不形成业务调用链或外部 I/O。
- MBean 运维可观测性：不适用；未新增缓存、常驻任务、队列、执行器或对象字段。

## 测试结果

- 命令：`mvn -o -q test`；`mvn -o -q -DskipTests compile`；`git diff --check`
- 新增/更新测试：`SeparatedStringTest` 覆盖 append 兼容语义；`SharedPathStringBenchmark` 覆盖设备 Topic 构造与深层遍历性能。
- 单元测试：632 passed, 0 failed, 0 errors, 1 skipped。
- 集成测试：不适用；未涉及数据库、网络、跨模块装配、外部 I/O 或实际消息投递链路。
- 压力测试：JMH 使用 Temurin JDK 21.0.10、G1、1 GiB 堆、2 fork、3 次 1 秒 warmup、5 次 1 秒 measurement 和 GCProfiler。单段 append 吞吐提升 8.57x，160.007 → 24.001 B/op；设备 event Topic 提升 5.94x，232.010 → 96.004 B/op；深度 8 的 `contentEquals`、`hashCode`、`length`、`toString` 分别提升 58.52x、2.47x、2.88x、1.76x。
- 覆盖率：`AbstractSeparatedCharSequence` line 114/147、branch 77/108；`AppendSeparatedCharSequence` line 17/20；`AppendSeparatedCharSequenceX` line 30/34。

## 文档同步情况

- 已同步：`docs/plans/shared-path-string-performance.md`，记录目标、兼容边界、实现取舍、JMH 原始指标与验证结果。
- 未同步：无。
- 说明：README 长期总览无需变化；JMH JSON/JFR 位于本地 `target/` 构建目录，不提交，正式数据已写入设计文档与 PR。

## 风险与说明

- 影响范围：`SharedPathString`/`SeparatedCharSequence` 的 append 及复合序列计算；未修改 EventBus SPI、Components 发布实现或 Device Manager 生产代码。
- 注释 / 公共契约：不涉及公共契约变更；关键性能取舍和分隔符遍历边界已补短注释。
- 链路追踪 / 可观测性：不涉及；纯内存字符序列运算，无异步、外部 I/O 或业务状态流转。
- MBean / 运维可观测性：不涉及；没有新增常驻状态、缓存、队列或后台执行器。
- 未覆盖场景：未执行端到端 EventBus 投递压测；本 PR 的基准只衡量 Topic 构造和字符序列操作。
- 已知限制：端到端收益仍受订阅匹配、序列化和消费端成本影响；完整 path append 不命中单段 fast path，保持原实现与分配水平。
